### PR TITLE
Deduplicate elastic

### DIFF
--- a/atomistics/shared/output.py
+++ b/atomistics/shared/output.py
@@ -78,26 +78,6 @@ class OutputEnergyVolumeCurve(
 
 
 @dataclasses.dataclass
-class OutputElastic(Output):
-    elastic_matrix: callable
-    elastic_matrix_inverse: callable
-    bulkmodul_voigt: callable
-    bulkmodul_reuss: callable
-    bulkmodul_hill: callable
-    shearmodul_voigt: callable
-    shearmodul_reuss: callable
-    shearmodul_hill: callable
-    youngsmodul_voigt: callable
-    youngsmodul_reuss: callable
-    youngsmodul_hill: callable
-    poissonsratio_voigt: callable
-    poissonsratio_reuss: callable
-    poissonsratio_hill: callable
-    AVR: callable
-    elastic_matrix_eigval: callable
-
-
-@dataclasses.dataclass
 class OutputPhonons(Output):
     mesh_dict: callable
     band_structure_dict: callable

--- a/atomistics/workflows/elastic/elastic_moduli.py
+++ b/atomistics/workflows/elastic/elastic_moduli.py
@@ -223,4 +223,7 @@ class OutputElastic(Output):
 
     @classmethod
     def fields(cls):
-        return tuple(q for q in dir(OutputElastic) if not (q[0] == "_" or q == "get"))
+        return tuple(
+            q for q in dir(cls)
+            if not (q[0] == "_" or q in ["get", "fields"])
+        )

--- a/atomistics/workflows/elastic/workflow.py
+++ b/atomistics/workflows/elastic/workflow.py
@@ -1,31 +1,10 @@
 import numpy as np
 
-from atomistics.shared.output import OutputElastic
 from atomistics.workflows.interface import Workflow
-from atomistics.workflows.elastic.elastic_moduli import ElasticProperties
+from atomistics.workflows.elastic.elastic_moduli import OutputElastic
 from atomistics.workflows.elastic.helper import (
     generate_structures_helper,
     analyse_structures_helper,
-)
-
-
-ElasticMatrixOutputElastic = OutputElastic(
-    elastic_matrix=ElasticProperties.get_elastic_matrix,
-    elastic_matrix_inverse=ElasticProperties.get_elastic_matrix_inverse,
-    bulkmodul_voigt=ElasticProperties.get_bulkmodul_voigt,
-    bulkmodul_reuss=ElasticProperties.get_bulkmodul_reuss,
-    bulkmodul_hill=ElasticProperties.get_bulkmodul_hill,
-    shearmodul_voigt=ElasticProperties.get_shearmodul_voigt,
-    shearmodul_reuss=ElasticProperties.get_shearmodul_reuss,
-    shearmodul_hill=ElasticProperties.get_shearmodul_hill,
-    youngsmodul_voigt=ElasticProperties.get_youngsmodul_voigt,
-    youngsmodul_reuss=ElasticProperties.get_youngsmodul_reuss,
-    youngsmodul_hill=ElasticProperties.get_youngsmodul_hill,
-    poissonsratio_voigt=ElasticProperties.get_poissonsratio_voigt,
-    poissonsratio_reuss=ElasticProperties.get_poissonsratio_reuss,
-    poissonsratio_hill=ElasticProperties.get_poissonratio_hill,
-    AVR=ElasticProperties.get_AVR,
-    elastic_matrix_eigval=ElasticProperties.get_elastic_matrix_eigval,
 )
 
 
@@ -81,6 +60,4 @@ class ElasticMatrixWorkflow(Workflow):
         self._data["strain_energy"] = strain_energy
         self._data["e0"] = ene0
         self._data["A2"] = A2
-        return ElasticMatrixOutputElastic.get(
-            ElasticProperties(elastic_matrix=elastic_matrix), *output
-        )
+        return OutputElastic(elastic_matrix).get(*output)


### PR DESCRIPTION
Instead of defining `ElasticMatrixOutputElastic` by populating the template `OutputElastic` with callables from the `engine` `ElasticProperties`, just make `OutputElastic` do the job to start with.