### PR TITLE
Abstract output

### DIFF
--- a/atomistics/shared/output.py
+++ b/atomistics/shared/output.py
@@ -1,8 +1,89 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
 import dataclasses
 
 
+class Output(ABC):
+    """
+    A base-class for holding output.
+
+    Promises that each piece of data has its name stored in the :meth:`fields` class
+    method, and that a subset of data can be easily accessed via the :meth:`get` method.
+    """
+    @classmethod
+    @abstractmethod
+    def fields(cls) -> tuple[str]:
+        """
+        The names of all the data held by this output class.
+        """
+
+    @abstractmethod
+    def get(self, *output: str) -> dict:
+        """
+        Gets a sub-set of the held data.
+
+        Args:
+            *output: Any number of :meth:`fields` elements.
+
+        Returns:
+            A sub-set of the held data as a dictionary.
+        """
+
+
+class PropertyOutput(Output):
+    """
+    :class:`Output` that expects all data to be available as properties (not just
+    post-init attributes -- it needs to be real class-level properties so it can be seen
+    in :meth:`fields`), and assumes that _all_ non-private attributes (excluding
+    :meth:`fields` and :meth:`get` already defined at the parent level) are data.
+
+    Examples)
+    >>> from atomistics.shared.output import PropertyOutput
+    >>>
+    >>> class MyOutput(PropertyOutput):
+    ...     def __init__(self, required_data: int):
+    ...         self._required_data = required_data
+    ...
+    ...     @property
+    ...     def required_data(self) -> int:
+    ...         return self._required_data
+    ...
+    ...     @property
+    ...     def only_got_half(self) -> float:
+    ...         return 0.5 * self.required_data
+    ('only_got_half', 'required_data')
+
+    >>> mo = MyOutput(42)
+    >>> mo.get("only_got_half")
+    {'only_got_half': 21.0}
+    """
+    def get(self, *output: str) -> dict:
+        """
+        A sub-set of available data as a dictionary.
+        """
+        return {q: getattr(self, q) for q in output}
+
+    @classmethod
+    def fields(cls):
+        """
+        Names of the data.
+        """
+        return tuple(
+            q for q in dir(cls)
+            if not (q[0] == "_" or q in ["get", "fields"])
+        )
+
+
 @dataclasses.dataclass
-class EngineOutput:
+class EngineOutput(Output):
+    """
+    :class:`Output` that places an `engine` between the data fields and the dictionary
+    returned by :meth:`get`. This allows us to define a single set of fields, but inject
+    another class (the `engine`) to modify how these data get calculated.
+
+    Engines provided to :meth:`get` must have properties for each of the data fields.
+    """
     @classmethod
     def fields(cls):
         return tuple(field.name for field in dataclasses.fields(cls))

--- a/atomistics/shared/output.py
+++ b/atomistics/shared/output.py
@@ -2,7 +2,7 @@ import dataclasses
 
 
 @dataclasses.dataclass
-class Output:
+class EngineOutput:
     @classmethod
     def fields(cls):
         return tuple(field.name for field in dataclasses.fields(cls))
@@ -12,7 +12,7 @@ class Output:
 
 
 @dataclasses.dataclass
-class OutputStatic(Output):
+class OutputStatic(EngineOutput):
     forces: callable
     energy: callable
     stress: callable
@@ -20,7 +20,7 @@ class OutputStatic(Output):
 
 
 @dataclasses.dataclass
-class OutputMolecularDynamics(Output):
+class OutputMolecularDynamics(EngineOutput):
     positions: callable
     cell: callable
     forces: callable
@@ -33,7 +33,7 @@ class OutputMolecularDynamics(Output):
 
 
 @dataclasses.dataclass
-class OutputThermalExpansion(Output):
+class OutputThermalExpansion(EngineOutput):
     temperatures: callable
     volumes: callable
 
@@ -46,22 +46,22 @@ class OutputThermodynamic(OutputThermalExpansion):
 
 
 @dataclasses.dataclass
-class EquilibriumEnergy(Output):
+class EquilibriumEnergy(EngineOutput):
     energy_eq: callable
 
 
 @dataclasses.dataclass
-class EquilibriumVolume(Output):
+class EquilibriumVolume(EngineOutput):
     volume_eq: callable
 
 
 @dataclasses.dataclass
-class EquilibriumBulkModul(Output):
+class EquilibriumBulkModul(EngineOutput):
     bulkmodul_eq: callable
 
 
 @dataclasses.dataclass
-class EquilibriumBulkModulDerivative(Output):
+class EquilibriumBulkModulDerivative(EngineOutput):
     b_prime_eq: callable
 
 
@@ -78,7 +78,7 @@ class OutputEnergyVolumeCurve(
 
 
 @dataclasses.dataclass
-class OutputPhonons(Output):
+class OutputPhonons(EngineOutput):
     mesh_dict: callable
     band_structure_dict: callable
     total_dos_dict: callable

--- a/atomistics/workflows/elastic/elastic_moduli.py
+++ b/atomistics/workflows/elastic/elastic_moduli.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 import numpy as np
 
-from atomistics.shared.output import Output
+from atomistics.shared.output import EngineOutput
 
 
 def get_bulkmodul_voigt(elastic_matrix) -> float:
@@ -123,7 +123,7 @@ def _hill_approximation(voigt, reuss):
     return 0.50 * (voigt + reuss)
 
 
-class OutputElastic(Output):
+class OutputElastic(EngineOutput):
     def __init__(self, elastic_matrix: np.ndarray):
         self._elastic_matrix = elastic_matrix
 

--- a/atomistics/workflows/elastic/elastic_moduli.py
+++ b/atomistics/workflows/elastic/elastic_moduli.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 import numpy as np
 
-from atomistics.shared.output import EngineOutput
+from atomistics.shared.output import PropertyOutput
 
 
 def get_bulkmodul_voigt(elastic_matrix) -> float:
@@ -123,7 +123,7 @@ def _hill_approximation(voigt, reuss):
     return 0.50 * (voigt + reuss)
 
 
-class OutputElastic(EngineOutput):
+class OutputElastic(PropertyOutput):
     def __init__(self, elastic_matrix: np.ndarray):
         self._elastic_matrix = elastic_matrix
 
@@ -217,10 +217,3 @@ class OutputElastic(EngineOutput):
     @cached_property
     def elastic_matrix_eigval(self):
         return get_elastic_matrix_eigval(elastic_matrix=self.elastic_matrix)
-
-    def get(self, *output: str) -> dict:
-        return {q: getattr(self, q) for q in output}
-
-    @classmethod
-    def fields(cls):
-        return tuple(q for q in dir(OutputElastic) if not (q[0] == "_" or q == "get"))


### PR DESCRIPTION
Take the microcosm of #166 and generalize it to two abstract output classes: one that needs an intermediate engine, and one that doesn't.