### PR TITLE
Rename output parameter to output_keys

### DIFF
--- a/atomistics/calculators/lammps/calculator.py
+++ b/atomistics/calculators/lammps/calculator.py
@@ -120,7 +120,7 @@ def calc_static_with_lammps(
     structure,
     potential_dataframe,
     lmp=None,
-    output=LammpsOutputStatic.fields(),
+    output_keys=LammpsOutputStatic.fields(),
     **kwargs,
 ):
     template_str = LAMMPS_THERMO_STYLE + "\n" + LAMMPS_THERMO + "\n" + LAMMPS_RUN
@@ -134,7 +134,7 @@ def calc_static_with_lammps(
         lmp=lmp,
         **kwargs,
     )
-    result_dict = LammpsOutputStatic.get(lmp_instance, *output)
+    result_dict = LammpsOutputStatic.get(lmp_instance, *output_keys)
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
 
@@ -151,7 +151,7 @@ def calc_molecular_dynamics_nvt_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.fields(),
     **kwargs,
 ):
     init_str = (
@@ -187,7 +187,7 @@ def calc_molecular_dynamics_nvt_with_lammps(
         run_str=run_str,
         run=run,
         thermo=thermo,
-        output=output,
+        output_keys=output_keys,
     )
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
@@ -208,7 +208,7 @@ def calc_molecular_dynamics_npt_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.fields(),
     **kwargs,
 ):
     init_str = (
@@ -247,7 +247,7 @@ def calc_molecular_dynamics_npt_with_lammps(
         run_str=run_str,
         run=run,
         thermo=thermo,
-        output=output,
+        output_keys=output_keys,
     )
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
@@ -266,7 +266,7 @@ def calc_molecular_dynamics_nph_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.fields(),
     **kwargs,
 ):
     init_str = (
@@ -302,7 +302,7 @@ def calc_molecular_dynamics_nph_with_lammps(
         run_str=run_str,
         run=run,
         thermo=thermo,
-        output=output,
+        output_keys=output_keys,
     )
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
@@ -320,7 +320,7 @@ def calc_molecular_dynamics_langevin_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.fields(),
     **kwargs,
 ):
     init_str = (
@@ -358,7 +358,7 @@ def calc_molecular_dynamics_langevin_with_lammps(
         run_str=run_str,
         run=run,
         thermo=thermo,
-        output=output,
+        output_keys=output_keys,
     )
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
@@ -380,7 +380,7 @@ def calc_molecular_dynamics_thermal_expansion_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansionProperties.fields(),
     **kwargs,
 ):
     init_str = (
@@ -411,7 +411,7 @@ def calc_molecular_dynamics_thermal_expansion_with_lammps(
         seed=seed,
         dist=dist,
         lmp=lmp,
-        output=output,
+        output_keys=output_keys,
         **kwargs,
     )
 
@@ -457,7 +457,7 @@ def evaluate_with_lammps_library(
             structure=structure,
             potential_dataframe=potential_dataframe,
             lmp=lmp,
-            output=get_quantities_from_tasks(tasks=tasks),
+            output_keys=get_quantities_from_tasks(tasks=tasks),
         )
     else:
         raise ValueError("The LAMMPS calculator does not implement:", tasks)

--- a/atomistics/calculators/lammps/helpers.py
+++ b/atomistics/calculators/lammps/helpers.py
@@ -46,11 +46,11 @@ def lammps_calc_md_step(
     lmp_instance,
     run_str,
     run,
-    output=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.fields(),
 ):
     run_str_rendered = Template(run_str).render(run=run)
     lmp_instance.interactive_lib_command(run_str_rendered)
-    return LammpsOutputMolecularDynamics.get(lmp_instance, *output)
+    return LammpsOutputMolecularDynamics.get(lmp_instance, *output_keys)
 
 
 def lammps_calc_md(
@@ -58,18 +58,18 @@ def lammps_calc_md(
     run_str,
     run,
     thermo,
-    output=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.fields(),
 ):
     results_lst = [
         lammps_calc_md_step(
             lmp_instance=lmp_instance,
             run_str=run_str,
             run=thermo,
-            output=output,
+            output_keys=output_keys,
         )
         for _ in range(run // thermo)
     ]
-    return {q: np.array([d[q] for d in results_lst]) for q in output}
+    return {q: np.array([d[q] for d in results_lst]) for q in output_keys}
 
 
 def lammps_thermal_expansion_loop(
@@ -88,7 +88,7 @@ def lammps_thermal_expansion_loop(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansionProperties.fields(),
     **kwargs,
 ):
     lmp_instance = lammps_run(
@@ -125,7 +125,7 @@ def lammps_thermal_expansion_loop(
         ThermalExpansionProperties(
             temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst
         ),
-        *output,
+        *output_keys,
     )
 
 

--- a/atomistics/calculators/qe.py
+++ b/atomistics/calculators/qe.py
@@ -189,7 +189,7 @@ def calc_static_with_qe(
     pseudopotentials=None,
     tstress=True,
     tprnfor=True,
-    output=OutputStatic.fields(),
+    output_keys=OutputStatic.fields(),
     **kwargs,
 ):
     input_file_name = os.path.join(working_directory, calculation_name + ".pwi")
@@ -216,7 +216,7 @@ def calc_static_with_qe(
         calculation_name=calculation_name, working_directory=working_directory
     )
     return QuantumEspressoOutputStatic.get(
-        QEStaticParser(filename=output_file_name), *output
+        QEStaticParser(filename=output_file_name), *output_keys
     )
 
 
@@ -255,7 +255,7 @@ def evaluate_with_qe(
             pseudopotentials=pseudopotentials,
             tstress=tstress,
             tprnfor=tprnfor,
-            output=get_quantities_from_tasks(tasks=tasks),
+            output_keys=get_quantities_from_tasks(tasks=tasks),
             **kwargs,
         )
     else:

--- a/atomistics/workflows/elastic/workflow.py
+++ b/atomistics/workflows/elastic/workflow.py
@@ -59,12 +59,12 @@ class ElasticMatrixWorkflow(Workflow):
         )
         return {"calc_energy": self._structure_dict}
 
-    def analyse_structures(self, output_dict, output=OutputElastic.fields()):
+    def analyse_structures(self, output_dict, output_keys=OutputElastic.fields()):
         """
 
         Args:
             output_dict (dict):
-            output (tuple):
+            output_keys (tuple):
 
         Returns:
 
@@ -82,5 +82,5 @@ class ElasticMatrixWorkflow(Workflow):
         self._data["e0"] = ene0
         self._data["A2"] = A2
         return ElasticMatrixOutputElastic.get(
-            ElasticProperties(elastic_matrix=elastic_matrix), *output
+            ElasticProperties(elastic_matrix=elastic_matrix), *output_keys
         )

--- a/atomistics/workflows/evcurve/debye.py
+++ b/atomistics/workflows/evcurve/debye.py
@@ -236,7 +236,7 @@ def get_thermal_properties(
     temperatures=None,
     constant_volume=False,
     num_steps=50,
-    output=OutputThermodynamic.fields(),
+    output_keys=OutputThermodynamic.fields(),
 ):
     return DebyeOutputThermodynamic.get(
         DebyeThermalProperties(
@@ -249,5 +249,5 @@ def get_thermal_properties(
             constant_volume=constant_volume,
             num_steps=num_steps,
         ),
-        *output,
+        *output_keys,
     )

--- a/atomistics/workflows/evcurve/workflow.py
+++ b/atomistics/workflows/evcurve/workflow.py
@@ -183,7 +183,7 @@ class EnergyVolumeCurveWorkflow(Workflow):
             self._structure_dict[1 + np.round(strain, 7)] = basis
         return {"calc_energy": self._structure_dict}
 
-    def analyse_structures(self, output_dict, output=OutputEnergyVolumeCurve.fields()):
+    def analyse_structures(self, output_dict, output_keys=OutputEnergyVolumeCurve.fields()):
         self._fit_dict = EnergyVolumeCurveOutputEnergyVolumeCurve.get(
             EnergyVolumeCurveProperties(
                 fit_module=fit_ev_curve_internal(
@@ -195,7 +195,7 @@ class EnergyVolumeCurveWorkflow(Workflow):
                     fit_order=self.fit_order,
                 )
             ),
-            *output,
+            *output_keys,
         )
         return self.fit_dict
 
@@ -214,7 +214,7 @@ class EnergyVolumeCurveWorkflow(Workflow):
             t_step=t_step,
             temperatures=temperatures,
             constant_volume=False,
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
         )
         return (
             thermal_properties_dict["temperatures"],
@@ -228,7 +228,7 @@ class EnergyVolumeCurveWorkflow(Workflow):
         t_step=50,
         temperatures=None,
         constant_volume=False,
-        output=OutputThermodynamic.fields(),
+        output_keys=OutputThermodynamic.fields(),
     ):
         return get_thermal_properties(
             fit_dict=self.fit_dict,
@@ -238,5 +238,5 @@ class EnergyVolumeCurveWorkflow(Workflow):
             t_step=t_step,
             temperatures=temperatures,
             constant_volume=constant_volume,
-            output=output,
+            output_keys=output_keys,
         )

--- a/atomistics/workflows/phonons/workflow.py
+++ b/atomistics/workflows/phonons/workflow.py
@@ -239,7 +239,7 @@ class PhonopyWorkflow(Workflow):
             structure.set_initial_magnetic_moments(magmoms)
         return structure
 
-    def analyse_structures(self, output_dict, output=OutputPhonons.fields()):
+    def analyse_structures(self, output_dict, output_keys=OutputPhonons.fields()):
         """
 
         Returns:
@@ -267,7 +267,7 @@ class PhonopyWorkflow(Workflow):
                 use_tetrahedron_method=True,
                 npoints=101,
             ),
-            *output,
+            *output_keys,
         )
         return self._phonopy_dict
 
@@ -281,7 +281,7 @@ class PhonopyWorkflow(Workflow):
         pretend_real=False,
         band_indices=None,
         is_projection=False,
-        output=OutputThermodynamic.fields(),
+        output_keys=OutputThermodynamic.fields(),
     ):
         """
         Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -308,7 +308,7 @@ class PhonopyWorkflow(Workflow):
             is_projection=is_projection,
         )
         return PhonopyOutputThermodynamic.get(
-            PhonopyThermalProperties(phonopy_instance=self.phonopy), *output
+            PhonopyThermalProperties(phonopy_instance=self.phonopy), *output_keys
         )
 
     def get_dynamical_matrix(self, npoints=101):

--- a/atomistics/workflows/quasiharmonic.py
+++ b/atomistics/workflows/quasiharmonic.py
@@ -36,7 +36,7 @@ def get_thermal_properties(
     band_indices=None,
     is_projection=False,
     quantum_mechanical=True,
-    output=OutputThermodynamic.fields(),
+    output_keys=OutputThermodynamic.fields(),
 ):
     """
     Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -64,7 +64,7 @@ def get_thermal_properties(
             pretend_real=pretend_real,
             band_indices=band_indices,
             is_projection=is_projection,
-            output=output,
+            output_keys=output_keys,
         )
     else:
         if is_projection:
@@ -111,7 +111,7 @@ def get_thermal_properties(
     if (
         not quantum_mechanical
     ):  # heat capacity and entropy are not yet implemented for the classical approach.
-        output = ["free_energy", "temperatures", "volumes"]
+        output_keys = ["free_energy", "temperatures", "volumes"]
     return QuasiHarmonicOutputThermodynamic.get(
         QuasiHarmonicThermalProperties(
             temperatures=temperatures,
@@ -120,7 +120,7 @@ def get_thermal_properties(
             volumes_lst=volume_lst,
             volumes_selected_lst=vol_lst,
         ),
-        *output,
+        *output_keys,
     )
 
 
@@ -135,7 +135,7 @@ def _get_thermal_properties_quantum_mechanical(
     pretend_real=False,
     band_indices=None,
     is_projection=False,
-    output=OutputThermodynamic.fields(),
+    output_keys=OutputThermodynamic.fields(),
 ):
     """
     Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -164,7 +164,7 @@ def _get_thermal_properties_quantum_mechanical(
                 pretend_real=pretend_real,
                 band_indices=band_indices,
                 is_projection=is_projection,
-                output=output,
+                output_keys=output_keys,
             ).items()
         }
     return tp_collect_dict
@@ -356,14 +356,14 @@ class QuasiHarmonicWorkflow(EnergyVolumeCurveWorkflow):
             )
         return task_dict
 
-    def analyse_structures(self, output_dict, output=("force_constants", "mesh_dict")):
+    def analyse_structures(self, output_dict, output_keys=("force_constants", "mesh_dict")):
         self._eng_internal_dict = output_dict["energy"]
         phonopy_collect_dict = {
             strain: phono.analyse_structures(
                 output_dict={
                     k: v for k, v in output_dict["forces"].items() if strain in k
                 },
-                output=output,
+                output_keys=output_keys,
             )
             for strain, phono in self._phonopy_dict.items()
         }
@@ -380,7 +380,7 @@ class QuasiHarmonicWorkflow(EnergyVolumeCurveWorkflow):
         band_indices=None,
         is_projection=False,
         quantum_mechanical=True,
-        output=OutputThermodynamic.fields(),
+        output_keys=OutputThermodynamic.fields(),
     ):
         """
         Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -416,7 +416,7 @@ class QuasiHarmonicWorkflow(EnergyVolumeCurveWorkflow):
             band_indices=band_indices,
             is_projection=is_projection,
             quantum_mechanical=quantum_mechanical,
-            output=OutputThermodynamic.fields(),
+            output_keys=OutputThermodynamic.fields(),
         )
 
     def get_thermal_expansion(
@@ -444,6 +444,6 @@ class QuasiHarmonicWorkflow(EnergyVolumeCurveWorkflow):
             band_indices=band_indices,
             is_projection=is_projection,
             quantum_mechanical=quantum_mechanical,
-            output=["free_energy", "temperatures", "volumes"],
+            output_keys=["free_energy", "temperatures", "volumes"],
         )
         return tp_collect_dict["temperatures"], tp_collect_dict["volumes"]

--- a/docs/source/materialproperties.md
+++ b/docs/source/materialproperties.md
@@ -382,7 +382,7 @@ import numpy as np
 workflow_ev.analyse_structures(output_dict=result_dict)
 thermal_properties_dict = workflow_ev.get_thermal_properties(
     temperatures=np.arange(1, 1500, 50),
-    output=["temperatures", "volumes"],
+    output_keys=["temperatures", "volumes"],
 )
 temperatures_ev, volume_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
 ```
@@ -461,7 +461,7 @@ and `get_thermal_properties()` functions:
 workflow_qh.analyse_structures(output_dict=result_dict)
 thermal_properties_dict_qm = workflow_qh.get_thermal_properties(
     temperatures=np.arange(1, 1500, 50),
-    output=["temperatures", "volumes"],
+    output_keys=["temperatures", "volumes"],
     quantum_mechanical=True
 )
 temperatures_qh_qm, volume_qh_qm = thermal_properties_dict_qm["temperatures"], thermal_properties_dict_qm["volumes"]
@@ -471,7 +471,7 @@ Here the extension `_qm` indicates that the quantum-mechanical harmonic oszillat
 ```
 thermal_properties_dict_cl = workflow_qh.get_thermal_properties(
     temperatures=np.arange(1, 1500, 50),
-    output=["temperatures", "volumes"],
+    output_keys=["temperatures", "volumes"],
     quantum_mechanical=False,
 )
 temperatures_qh_cl, volume_qh_cl = thermal_properties_dict_cl["temperatures"], thermal_properties_dict_cl["volumes"]

--- a/docs/source/workflows.md
+++ b/docs/source/workflows.md
@@ -148,7 +148,7 @@ result_dict = calc_molecular_dynamics_langevin_with_lammps(
     timestep=0.001,
     seed=4928459,
     dist="gaussian",
-    output=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
+    output_keys=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
 )
 ```
 In addition to the typical LAMMPS input parameters like the atomistic structure `structure` as `ase.atoms.Atoms` object
@@ -189,7 +189,7 @@ result_dict = calc_molecular_dynamics_nvt_with_lammps(
     timestep=0.001,
     seed=4928459,
     dist="gaussian",
-    output=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
+    output_keys=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
 )
 ```
 In addition to the typical LAMMPS input parameters like the atomistic structure `structure` as `ase.atoms.Atoms` object
@@ -232,7 +232,7 @@ result_dict = calc_molecular_dynamics_npt_with_lammps(
     Pdamp=1.0,
     seed=4928459,
     dist="gaussian",
-    output=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
+    output_keys=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
 )
 ```
 The input parameters for the isothermal-isobaric ensemble (npt) are the same as for the canonical ensemble (nvt) plus:
@@ -264,7 +264,7 @@ result_dict = calc_molecular_dynamics_nph_with_lammps(
     Pdamp=1.0,
     seed=4928459,
     dist="gaussian",
-    output=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
+    output_keys=("positions", "cell", "forces", "temperature", "energy_pot", "energy_tot", "pressure", "velocities"),
 )
 ```
 

--- a/docs/source/workflows.md
+++ b/docs/source/workflows.md
@@ -109,7 +109,7 @@ thermal_properties_dict = workflow.get_thermal_properties(
     t_step=50, 
     temperatures=None,
     constant_volume=False,
-    output=["temperatures", "volumes"],
+    output_keys=["temperatures", "volumes"],
 )
 temperatures, volumes = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
 ```
@@ -639,7 +639,7 @@ tp_dict = workflow.get_thermal_properties(
     band_indices=None,
     is_projection=False,
     quantum_mechanical=True,
-    output=["temperatures", "volumes"],
+    output_keys=["temperatures", "volumes"],
 )
 temperatures, volumes = tp_dict["temperatures"], tp_dict["volumes"]
 ```

--- a/notebooks/lammps_workflows.ipynb
+++ b/notebooks/lammps_workflows.ipynb
@@ -277,7 +277,7 @@
     "    t_max=1500, \n",
     "    t_step=50, \n",
     "    constant_volume=False,\n",
-    "    output=[\"temperatures\", \"volumes\"],\n",
+    "    output_keys=[\"temperatures\", \"volumes\"],\n",
     ")\n",
     "temperatures, volumes = thermal_properties_dict[\"temperatures\"], thermal_properties_dict[\"volumes\"]"
    ]
@@ -3078,7 +3078,7 @@
     "    band_indices=None,\n",
     "    is_projection=False,\n",
     "    quantum_mechanical=True,\n",
-    "    output=[\"temperatures\", \"volumes\"],\n",
+    "    output_keys=[\"temperatures\", \"volumes\"],\n",
     ")\n",
     "temperatures, volumes = tp_dict[\"temperatures\"], tp_dict[\"volumes\"]"
    ]

--- a/notebooks/lammps_workflows.ipynb
+++ b/notebooks/lammps_workflows.ipynb
@@ -348,7 +348,7 @@
     "    timestep=0.001,\n",
     "    seed=4928459,\n",
     "    dist=\"gaussian\",\n",
-    "    output=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\", \"velocities\"),\n",
+    "    output_keys=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\", \"velocities\"),\n",
     ")"
    ]
   },
@@ -409,7 +409,7 @@
     "    timestep=0.001,\n",
     "    seed=4928459,\n",
     "    dist=\"gaussian\",\n",
-    "    output=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\"),\n",
+    "    output_keys=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\"),\n",
     ")"
    ]
   },
@@ -472,7 +472,7 @@
     "    Pdamp=1.0,\n",
     "    seed=4928459,\n",
     "    dist=\"gaussian\",\n",
-    "    output=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\"),\n",
+    "    output_keys=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\"),\n",
     ")"
    ]
   },
@@ -524,7 +524,7 @@
     "    Pdamp=1.0,\n",
     "    seed=4928459,\n",
     "    dist=\"gaussian\",\n",
-    "    output=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\"),\n",
+    "    output_keys=(\"positions\", \"cell\", \"forces\", \"temperature\", \"energy_pot\", \"energy_tot\", \"pressure\"),\n",
     ")"
    ]
   },

--- a/notebooks/thermal_expansion_with_lammps.ipynb
+++ b/notebooks/thermal_expansion_with_lammps.ipynb
@@ -350,7 +350,7 @@
     "workflow_ev.analyse_structures(output_dict=result_dict)\n",
     "thermal_properties_dict = workflow_ev.get_thermal_properties(\n",
     "    temperatures=np.arange(1, 1500, 50),\n",
-    "    output=[\"temperatures\", \"volumes\"],\n",
+    "    output_keys=[\"temperatures\", \"volumes\"],\n",
     ")\n",
     "temperatures_ev, volume_ev = thermal_properties_dict[\"temperatures\"], thermal_properties_dict[\"volumes\"]"
    ]
@@ -504,7 +504,7 @@
     "workflow_qh.analyse_structures(output_dict=result_dict)\n",
     "thermal_properties_dict_qm = workflow_qh.get_thermal_properties(\n",
     "    temperatures=np.arange(1, 1500, 50),\n",
-    "    output=[\"temperatures\", \"volumes\"],\n",
+    "    output_keys=[\"temperatures\", \"volumes\"],\n",
     "    quantum_mechanical=True\n",
     ")\n",
     "temperatures_qh_qm, volume_qh_qm = thermal_properties_dict_qm[\"temperatures\"], thermal_properties_dict_qm[\"volumes\"]"
@@ -527,7 +527,7 @@
    "source": [
     "thermal_properties_dict_cl = workflow_qh.get_thermal_properties(\n",
     "    temperatures=np.arange(1, 1500, 50),\n",
-    "    output=[\"temperatures\", \"volumes\"],\n",
+    "    output_keys=[\"temperatures\", \"volumes\"],\n",
     "    quantum_mechanical=False,\n",
     ")\n",
     "temperatures_qh_cl, volume_qh_cl = thermal_properties_dict_cl[\"temperatures\"], thermal_properties_dict_cl[\"volumes\"]"

--- a/tests/test_evcurve_ase_abinit.py
+++ b/tests/test_evcurve_ase_abinit.py
@@ -58,7 +58,7 @@ class TestEvCurve(unittest.TestCase):
         fit_dict = workflow.analyse_structures(output_dict=result_dict)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"]
+            output_keys=["temperatures", "volumes"]
         )
         temperatures_ev, volumes_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         self.assertTrue(all(validate_fitdict(fit_dict=fit_dict)))

--- a/tests/test_evcurve_ase_emt.py
+++ b/tests/test_evcurve_ase_emt.py
@@ -32,7 +32,7 @@ class TestEvCurve(unittest.TestCase):
         fit_dict = workflow.analyse_structures(output_dict=result_dict)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"]
+            output_keys=["temperatures", "volumes"]
         )
         temperatures_ev, volumes_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         self.assertTrue(np.isclose(fit_dict['volume_eq'], 63.72747170239313))

--- a/tests/test_evcurve_ase_gpaw.py
+++ b/tests/test_evcurve_ase_gpaw.py
@@ -40,7 +40,7 @@ class TestEvCurve(unittest.TestCase):
         fit_dict = workflow.analyse_structures(output_dict=result_dict)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"]
+            output_keys=["temperatures", "volumes"]
         )
         temperatures_ev, volumes_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         self.assertTrue(np.isclose(fit_dict['volume_eq'], 66.44252286131331, atol=1e-04))

--- a/tests/test_evcurve_ase_lammps.py
+++ b/tests/test_evcurve_ase_lammps.py
@@ -58,7 +58,7 @@ class TestEvCurve(unittest.TestCase):
         fit_dict = workflow.analyse_structures(output_dict=result_dict)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"]
+            output_keys=["temperatures", "volumes"]
         )
         temperatures_ev, volumes_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         self.assertTrue(np.isclose(fit_dict['volume_eq'], 66.29753110818122))

--- a/tests/test_evcurve_ase_matgl.py
+++ b/tests/test_evcurve_ase_matgl.py
@@ -47,7 +47,7 @@ class TestEvCurve(unittest.TestCase):
         fit_dict = workflow.analyse_structures(output_dict=result_dict)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"]
+            output_keys=["temperatures", "volumes"]
         )
         temperatures_ev, volumes_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         self.assertTrue(np.isclose(fit_dict['volume_eq'], 66.56048874824006, atol=1e-04))

--- a/tests/test_evcurve_lammps.py
+++ b/tests/test_evcurve_lammps.py
@@ -49,7 +49,7 @@ class TestEvCurve(unittest.TestCase):
         fit_dict = workflow.analyse_structures(output_dict=result_dict)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"]
+            output_keys=["temperatures", "volumes"]
         )
         temperatures_ev, volumes_ev = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         self.assertTrue(np.isclose(fit_dict['volume_eq'], 66.43019853103964))

--- a/tests/test_lammps_md.py
+++ b/tests/test_lammps_md.py
@@ -71,7 +71,7 @@ class TestLammpsMD(unittest.TestCase):
             seed=4928459,
             dist="gaussian",
             lmp=None,
-            output=("temperature",),
+            output_keys=("temperature",),
         )
         self.assertEqual(len(result_dict.keys()), 1)
         self.assertEqual(result_dict["temperature"].shape, (10, ))

--- a/tests/test_lammps_md.py
+++ b/tests/test_lammps_md.py
@@ -174,7 +174,7 @@ class TestLammpsMD(unittest.TestCase):
 
     def test_calc_molecular_dynamics_signature(self):
         self.assertEqual(
-            inspect.signature(calc_molecular_dynamics_nvt_with_lammps).parameters["output"].default,
+            inspect.signature(calc_molecular_dynamics_nvt_with_lammps).parameters["output_keys"].default,
             (
                 "positions",
                 "cell",

--- a/tests/test_phonons_lammps.py
+++ b/tests/test_phonons_lammps.py
@@ -94,7 +94,7 @@ class TestPhonons(unittest.TestCase):
             pretend_real=False,
             band_indices=None,
             is_projection=False,
-            output=["temperatures", "free_energy"]
+            output_keys=["temperatures", "free_energy"]
         )
         self.assertEqual(len(thermal_dict.keys()), 2)
         self.assertEqual(thermal_dict["temperatures"][0], 1.0)

--- a/tests/test_quasiharmonic_ase_emt.py
+++ b/tests/test_quasiharmonic_ase_emt.py
@@ -38,13 +38,13 @@ class TestPhonons(unittest.TestCase):
         tp_collect_dict = workflow.get_thermal_properties(t_min=1, t_max=1500, t_step=50, temperatures=None)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
             quantum_mechanical=True
         )
         temperatures_qh_qm, volumes_qh_qm = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
             quantum_mechanical=False
         )
         temperatures_qh_cl, volumes_qh_cl = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]

--- a/tests/test_quasiharmonic_ase_matgl.py
+++ b/tests/test_quasiharmonic_ase_matgl.py
@@ -50,13 +50,13 @@ class TestPhonons(unittest.TestCase):
         tp_collect_dict = workflow.get_thermal_properties(t_min=1, t_max=501, t_step=50, temperatures=None)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 500],
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
             quantum_mechanical=True
         )
         temperatures_qh_qm, volumes_qh_qm = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 500],
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
             quantum_mechanical=False
         )
         temperatures_qh_cl, volumes_qh_cl = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]

--- a/tests/test_quasiharmonic_lammps.py
+++ b/tests/test_quasiharmonic_lammps.py
@@ -71,13 +71,13 @@ class TestPhonons(unittest.TestCase):
         self.assertTrue(tp_collect_dict["volumes"][0] > 66.7)
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
             quantum_mechanical=True
         )
         temperatures_qh_qm, volumes_qh_qm = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]
         thermal_properties_dict = workflow.get_thermal_properties(
             temperatures=[100, 1000],
-            output=["temperatures", "volumes"],
+            output_keys=["temperatures", "volumes"],
             quantum_mechanical=False
         )
         temperatures_qh_cl, volumes_qh_cl = thermal_properties_dict["temperatures"], thermal_properties_dict["volumes"]


### PR DESCRIPTION
To be more explicit the parameter `output` is renamed to `output_keys`. Previously this change was included in https://github.com/pyiron/atomistics/pull/176 - now it is separated in a separate pull request. 