### PR TITLE
Rename fields() to keys()

### DIFF
--- a/atomistics/calculators/ase.py
+++ b/atomistics/calculators/ase.py
@@ -66,11 +66,11 @@ class ASEExecutor(object):
 
 
 ASEOutputStatic = OutputStatic(
-    **{k: getattr(ASEExecutor, k) for k in OutputStatic.fields()}
+    **{k: getattr(ASEExecutor, k) for k in OutputStatic.keys()}
 )
 
 ASEOutputMolecularDynamics = OutputMolecularDynamics(
-    **{k: getattr(ASEExecutor, k) for k in OutputMolecularDynamics.fields()}
+    **{k: getattr(ASEExecutor, k) for k in OutputMolecularDynamics.keys()}
 )
 
 
@@ -113,7 +113,7 @@ def evaluate_with_ase(
 def calc_static_with_ase(
     structure,
     ase_calculator,
-    output_keys=OutputStatic.fields(),
+    output_keys=OutputStatic.keys(),
 ):
     return ASEOutputStatic.get(
         ASEExecutor(ase_structure=structure, ase_calculator=ase_calculator),
@@ -148,7 +148,7 @@ def calc_molecular_dynamics_npt_with_ase(
     pfactor=2e6 * units.GPa * (units.fs**2),
     temperature=100,
     externalstress=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * units.bar,
-    output_keys=ASEOutputMolecularDynamics.fields(),
+    output_keys=ASEOutputMolecularDynamics.keys(),
 ):
     return _calc_md_step_with_ase(
         dyn=NPT(
@@ -182,7 +182,7 @@ def calc_molecular_dynamics_langevin_with_ase(
     timestep=1 * units.fs,
     temperature=100,
     friction=0.002,
-    output_keys=ASEOutputMolecularDynamics.fields(),
+    output_keys=ASEOutputMolecularDynamics.keys(),
 ):
     return _calc_md_step_with_ase(
         dyn=Langevin(
@@ -232,7 +232,7 @@ def calc_molecular_dynamics_thermal_expansion_with_ase(
     ttime=100 * units.fs,
     pfactor=2e6 * units.GPa * (units.fs**2),
     externalstress=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * units.bar,
-    output_keys=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansionProperties.keys(),
 ):
     structure_current = structure.copy()
     temperature_lst = np.arange(

--- a/atomistics/calculators/lammps/calculator.py
+++ b/atomistics/calculators/lammps/calculator.py
@@ -120,7 +120,7 @@ def calc_static_with_lammps(
     structure,
     potential_dataframe,
     lmp=None,
-    output_keys=LammpsOutputStatic.fields(),
+    output_keys=LammpsOutputStatic.keys(),
     **kwargs,
 ):
     template_str = LAMMPS_THERMO_STYLE + "\n" + LAMMPS_THERMO + "\n" + LAMMPS_RUN
@@ -151,7 +151,7 @@ def calc_molecular_dynamics_nvt_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.keys(),
     **kwargs,
 ):
     init_str = (
@@ -208,7 +208,7 @@ def calc_molecular_dynamics_npt_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.keys(),
     **kwargs,
 ):
     init_str = (
@@ -266,7 +266,7 @@ def calc_molecular_dynamics_nph_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.keys(),
     **kwargs,
 ):
     init_str = (
@@ -320,7 +320,7 @@ def calc_molecular_dynamics_langevin_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.keys(),
     **kwargs,
 ):
     init_str = (
@@ -380,7 +380,7 @@ def calc_molecular_dynamics_thermal_expansion_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansionProperties.keys(),
     **kwargs,
 ):
     init_str = (

--- a/atomistics/calculators/lammps/helpers.py
+++ b/atomistics/calculators/lammps/helpers.py
@@ -46,7 +46,7 @@ def lammps_calc_md_step(
     lmp_instance,
     run_str,
     run,
-    output_keys=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.keys(),
 ):
     run_str_rendered = Template(run_str).render(run=run)
     lmp_instance.interactive_lib_command(run_str_rendered)
@@ -58,7 +58,7 @@ def lammps_calc_md(
     run_str,
     run,
     thermo,
-    output_keys=LammpsOutputMolecularDynamics.fields(),
+    output_keys=LammpsOutputMolecularDynamics.keys(),
 ):
     results_lst = [
         lammps_calc_md_step(
@@ -88,7 +88,7 @@ def lammps_thermal_expansion_loop(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansionProperties.keys(),
     **kwargs,
 ):
     lmp_instance = lammps_run(

--- a/atomistics/calculators/qe.py
+++ b/atomistics/calculators/qe.py
@@ -27,7 +27,7 @@ class QEStaticParser(object):
 
 
 QuantumEspressoOutputStatic = OutputStatic(
-    **{k: getattr(QEStaticParser, k) for k in OutputStatic.fields()}
+    **{k: getattr(QEStaticParser, k) for k in OutputStatic.keys()}
 )
 
 
@@ -186,7 +186,7 @@ def calc_static_with_qe(
     pseudopotentials=None,
     tstress=True,
     tprnfor=True,
-    output_keys=OutputStatic.fields(),
+    output_keys=OutputStatic.keys(),
     **kwargs,
 ):
     input_file_name = os.path.join(working_directory, calculation_name + ".pwi")

--- a/atomistics/shared/output.py
+++ b/atomistics/shared/output.py
@@ -4,7 +4,7 @@ import dataclasses
 @dataclasses.dataclass
 class Output:
     @classmethod
-    def fields(cls):
+    def keys(cls):
         return tuple(field.name for field in dataclasses.fields(cls))
 
     def get(self, engine, *output: str) -> dict:

--- a/atomistics/shared/thermal_expansion.py
+++ b/atomistics/shared/thermal_expansion.py
@@ -16,6 +16,6 @@ class ThermalExpansionProperties:
 OutputThermalExpansionProperties = OutputThermalExpansion(
     **{
         k: getattr(ThermalExpansionProperties, k)
-        for k in OutputThermalExpansion.fields()
+        for k in OutputThermalExpansion.keys()
     }
 )

--- a/atomistics/shared/thermal_expansion.py
+++ b/atomistics/shared/thermal_expansion.py
@@ -14,8 +14,5 @@ class ThermalExpansionProperties:
 
 
 OutputThermalExpansionProperties = OutputThermalExpansion(
-    **{
-        k: getattr(ThermalExpansionProperties, k)
-        for k in OutputThermalExpansion.keys()
-    }
+    **{k: getattr(ThermalExpansionProperties, k) for k in OutputThermalExpansion.keys()}
 )

--- a/atomistics/workflows/elastic/workflow.py
+++ b/atomistics/workflows/elastic/workflow.py
@@ -10,7 +10,7 @@ from atomistics.workflows.elastic.helper import (
 
 
 elastic_matrix_output_elastic = OutputElastic(
-    **{k: getattr(ElasticProperties, k) for k in OutputElastic.fields()}
+    **{k: getattr(ElasticProperties, k) for k in OutputElastic.keys()}
 )
 
 
@@ -44,7 +44,7 @@ class ElasticMatrixWorkflow(Workflow):
         )
         return {"calc_energy": self._structure_dict}
 
-    def analyse_structures(self, output_dict, output_keys=OutputElastic.fields()):
+    def analyse_structures(self, output_dict, output_keys=OutputElastic.keys()):
         """
 
         Args:

--- a/atomistics/workflows/evcurve/debye.py
+++ b/atomistics/workflows/evcurve/debye.py
@@ -77,7 +77,7 @@ class DebyeThermalProperties(object):
 
 
 DebyeOutputThermodynamic = OutputThermodynamic(
-    **{k: getattr(DebyeThermalProperties, k) for k in OutputThermodynamic.fields()}
+    **{k: getattr(DebyeThermalProperties, k) for k in OutputThermodynamic.keys()}
 )
 
 
@@ -232,7 +232,7 @@ def get_thermal_properties(
     temperatures=None,
     constant_volume=False,
     num_steps=50,
-    output_keys=OutputThermodynamic.fields(),
+    output_keys=OutputThermodynamic.keys(),
 ):
     return DebyeOutputThermodynamic.get(
         DebyeThermalProperties(

--- a/atomistics/workflows/evcurve/workflow.py
+++ b/atomistics/workflows/evcurve/workflow.py
@@ -130,7 +130,7 @@ class EnergyVolumeCurveProperties:
 EnergyVolumeCurveOutputEnergyVolumeCurve = OutputEnergyVolumeCurve(
     **{
         k: getattr(EnergyVolumeCurveProperties, k)
-        for k in OutputEnergyVolumeCurve.fields()
+        for k in OutputEnergyVolumeCurve.keys()
     }
 )
 
@@ -181,7 +181,7 @@ class EnergyVolumeCurveWorkflow(Workflow):
         return {"calc_energy": self._structure_dict}
 
     def analyse_structures(
-        self, output_dict, output_keys=OutputEnergyVolumeCurve.fields()
+        self, output_dict, output_keys=OutputEnergyVolumeCurve.keys()
     ):
         self._fit_dict = EnergyVolumeCurveOutputEnergyVolumeCurve.get(
             EnergyVolumeCurveProperties(
@@ -208,7 +208,7 @@ class EnergyVolumeCurveWorkflow(Workflow):
         t_step=50,
         temperatures=None,
         constant_volume=False,
-        output_keys=OutputThermodynamic.fields(),
+        output_keys=OutputThermodynamic.keys(),
     ):
         return get_thermal_properties(
             fit_dict=self.fit_dict,

--- a/atomistics/workflows/phonons/workflow.py
+++ b/atomistics/workflows/phonons/workflow.py
@@ -142,10 +142,10 @@ class PhonopyThermalProperties(object):
 
 
 PhonopyOutputPhonons = OutputPhonons(
-    **{k: getattr(PhonopyProperties, k) for k in OutputPhonons.fields()}
+    **{k: getattr(PhonopyProperties, k) for k in OutputPhonons.keys()}
 )
 PhonopyOutputThermodynamic = OutputThermodynamic(
-    **{k: getattr(PhonopyThermalProperties, k) for k in OutputThermodynamic.fields()}
+    **{k: getattr(PhonopyThermalProperties, k) for k in OutputThermodynamic.keys()}
 )
 
 
@@ -231,7 +231,7 @@ class PhonopyWorkflow(Workflow):
             structure.set_initial_magnetic_moments(magmoms)
         return structure
 
-    def analyse_structures(self, output_dict, output_keys=OutputPhonons.fields()):
+    def analyse_structures(self, output_dict, output_keys=OutputPhonons.keys()):
         """
 
         Returns:
@@ -273,7 +273,7 @@ class PhonopyWorkflow(Workflow):
         pretend_real=False,
         band_indices=None,
         is_projection=False,
-        output_keys=OutputThermodynamic.fields(),
+        output_keys=OutputThermodynamic.keys(),
     ):
         """
         Returns thermal properties at constant volume in the given temperature range.  Can only be called after job

--- a/atomistics/workflows/quasiharmonic.py
+++ b/atomistics/workflows/quasiharmonic.py
@@ -36,7 +36,7 @@ def get_thermal_properties(
     band_indices=None,
     is_projection=False,
     quantum_mechanical=True,
-    output_keys=OutputThermodynamic.fields(),
+    output_keys=OutputThermodynamic.keys(),
 ):
     """
     Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -135,7 +135,7 @@ def _get_thermal_properties_quantum_mechanical(
     pretend_real=False,
     band_indices=None,
     is_projection=False,
-    output_keys=OutputThermodynamic.fields(),
+    output_keys=OutputThermodynamic.keys(),
 ):
     """
     Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -277,7 +277,7 @@ class QuasiHarmonicThermalProperties(object):
 QuasiHarmonicOutputThermodynamic = OutputThermodynamic(
     **{
         k: getattr(QuasiHarmonicThermalProperties, k)
-        for k in OutputThermodynamic.fields()
+        for k in OutputThermodynamic.keys()
     }
 )
 
@@ -381,7 +381,7 @@ class QuasiHarmonicWorkflow(EnergyVolumeCurveWorkflow):
         band_indices=None,
         is_projection=False,
         quantum_mechanical=True,
-        output_keys=OutputThermodynamic.fields(),
+        output_keys=OutputThermodynamic.keys(),
     ):
         """
         Returns thermal properties at constant volume in the given temperature range.  Can only be called after job
@@ -417,5 +417,5 @@ class QuasiHarmonicWorkflow(EnergyVolumeCurveWorkflow):
             band_indices=band_indices,
             is_projection=is_projection,
             quantum_mechanical=quantum_mechanical,
-            output_keys=OutputThermodynamic.fields(),
+            output_keys=OutputThermodynamic.keys(),
         )


### PR DESCRIPTION
For consistency with https://github.com/pyiron/atomistics/pull/180 - I renamed the `fields()` function of the output interface class to `keys()` - as it was already done in https://github.com/pyiron/atomistics/pull/176 previously. 