### PR TITLE
Introduce get_thermal_expansion_output() function

### DIFF
--- a/atomistics/calculators/ase.py
+++ b/atomistics/calculators/ase.py
@@ -11,10 +11,8 @@ from typing import TYPE_CHECKING
 from atomistics.calculators.interface import get_quantities_from_tasks
 from atomistics.calculators.wrapper import as_task_dict_evaluator
 from atomistics.shared.output import OutputStatic, OutputMolecularDynamics
-from atomistics.shared.thermal_expansion import (
-    OutputThermalExpansionProperties,
-    ThermalExpansionProperties,
-)
+from atomistics.shared.thermal_expansion import get_thermal_expansion_output
+from atomistics.shared.output import OutputThermalExpansion
 from atomistics.shared.tqdm_iterator import get_tqdm_iterator
 
 if TYPE_CHECKING:
@@ -232,7 +230,7 @@ def calc_molecular_dynamics_thermal_expansion_with_ase(
     ttime=100 * units.fs,
     pfactor=2e6 * units.GPa * (units.fs**2),
     externalstress=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * units.bar,
-    output_keys=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansion.fields(),
 ):
     structure_current = structure.copy()
     temperature_lst = np.arange(
@@ -254,9 +252,4 @@ def calc_molecular_dynamics_thermal_expansion_with_ase(
         structure_current.set_cell(cell=result_dict["cell"][-1], scale_atoms=True)
         temperature_md_lst.append(result_dict["temperature"][-1])
         volume_md_lst.append(result_dict["volume"][-1])
-    return OutputThermalExpansionProperties.get(
-        ThermalExpansionProperties(
-            temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst
-        ),
-        *output_keys,
-    )
+    return get_thermal_expansion_output(temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst, output_keys=output_keys)

--- a/atomistics/calculators/ase.py
+++ b/atomistics/calculators/ase.py
@@ -252,4 +252,8 @@ def calc_molecular_dynamics_thermal_expansion_with_ase(
         structure_current.set_cell(cell=result_dict["cell"][-1], scale_atoms=True)
         temperature_md_lst.append(result_dict["temperature"][-1])
         volume_md_lst.append(result_dict["volume"][-1])
-    return get_thermal_expansion_output(temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst, output_keys=output_keys)
+    return get_thermal_expansion_output(
+        temperatures_lst=temperature_md_lst,
+        volumes_lst=volume_md_lst,
+        output_keys=output_keys,
+    )

--- a/atomistics/calculators/lammps/calculator.py
+++ b/atomistics/calculators/lammps/calculator.py
@@ -32,7 +32,7 @@ from atomistics.calculators.lammps.output import (
     LammpsOutputStatic,
 )
 from atomistics.calculators.wrapper import as_task_dict_evaluator
-from atomistics.shared.thermal_expansion import OutputThermalExpansionProperties
+from atomistics.shared.output import OutputThermalExpansion
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -380,7 +380,7 @@ def calc_molecular_dynamics_thermal_expansion_with_lammps(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansion.fields(),
     **kwargs,
 ):
     init_str = (

--- a/atomistics/calculators/lammps/helpers.py
+++ b/atomistics/calculators/lammps/helpers.py
@@ -119,7 +119,11 @@ def lammps_thermal_expansion_loop(
         volume_md_lst.append(lmp_instance.interactive_volume_getter())
         temperature_md_lst.append(lmp_instance.interactive_temperatures_getter())
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
-    return get_thermal_expansion_output(temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst, output_keys=output_keys)
+    return get_thermal_expansion_output(
+        temperatures_lst=temperature_md_lst,
+        volumes_lst=volume_md_lst,
+        output_keys=output_keys,
+    )
 
 
 def lammps_shutdown(lmp_instance, close_instance=True):

--- a/atomistics/calculators/lammps/helpers.py
+++ b/atomistics/calculators/lammps/helpers.py
@@ -6,10 +6,8 @@ from pylammpsmpi import LammpsASELibrary
 
 from atomistics.calculators.lammps.potential import validate_potential_dataframe
 from atomistics.calculators.lammps.output import LammpsOutputMolecularDynamics
-from atomistics.shared.thermal_expansion import (
-    OutputThermalExpansionProperties,
-    ThermalExpansionProperties,
-)
+from atomistics.shared.thermal_expansion import get_thermal_expansion_output
+from atomistics.shared.output import OutputThermalExpansion
 from atomistics.shared.tqdm_iterator import get_tqdm_iterator
 
 
@@ -88,7 +86,7 @@ def lammps_thermal_expansion_loop(
     seed=4928459,
     dist="gaussian",
     lmp=None,
-    output_keys=OutputThermalExpansionProperties.fields(),
+    output_keys=OutputThermalExpansion.fields(),
     **kwargs,
 ):
     lmp_instance = lammps_run(
@@ -121,12 +119,7 @@ def lammps_thermal_expansion_loop(
         volume_md_lst.append(lmp_instance.interactive_volume_getter())
         temperature_md_lst.append(lmp_instance.interactive_temperatures_getter())
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
-    return OutputThermalExpansionProperties.get(
-        ThermalExpansionProperties(
-            temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst
-        ),
-        *output_keys,
-    )
+    return get_thermal_expansion_output(temperatures_lst=temperature_md_lst, volumes_lst=volume_md_lst, output_keys=output_keys)
 
 
 def lammps_shutdown(lmp_instance, close_instance=True):

--- a/atomistics/shared/thermal_expansion.py
+++ b/atomistics/shared/thermal_expansion.py
@@ -13,9 +13,5 @@ class ThermalExpansionProperties:
         return self._temperatures_lst
 
 
-OutputThermalExpansionProperties = OutputThermalExpansion(
-    **{
-        k: getattr(ThermalExpansionProperties, k)
-        for k in OutputThermalExpansion.fields()
-    }
-)
+def get_thermal_expansion_output(temperatures_lst, volumes_lst, output_keys):
+    return OutputThermalExpansion(**{k: getattr(ThermalExpansionProperties, k) for k in OutputThermalExpansion.fields()}).get(ThermalExpansionProperties(temperatures_lst=temperatures_lst, volumes_lst=volumes_lst),*output_keys)

--- a/atomistics/shared/thermal_expansion.py
+++ b/atomistics/shared/thermal_expansion.py
@@ -14,4 +14,14 @@ class ThermalExpansionProperties:
 
 
 def get_thermal_expansion_output(temperatures_lst, volumes_lst, output_keys):
-    return OutputThermalExpansion(**{k: getattr(ThermalExpansionProperties, k) for k in OutputThermalExpansion.fields()}).get(ThermalExpansionProperties(temperatures_lst=temperatures_lst, volumes_lst=volumes_lst),*output_keys)
+    return OutputThermalExpansion(
+        **{
+            k: getattr(ThermalExpansionProperties, k)
+            for k in OutputThermalExpansion.fields()
+        }
+    ).get(
+        ThermalExpansionProperties(
+            temperatures_lst=temperatures_lst, volumes_lst=volumes_lst
+        ),
+        *output_keys,
+    )


### PR DESCRIPTION
Remove the code duplication of defining multiple instances of the `ThermalExpansionOutput` by defining one function to create the corresponding output object: 
```python
def get_thermal_expansion_output(temperatures_lst, volumes_lst, output_keys):
    return OutputThermalExpansion(
        **{
            k: getattr(ThermalExpansionProperties, k)
            for k in OutputThermalExpansion.fields()
        }
    ).get(
        ThermalExpansionProperties(
            temperatures_lst=temperatures_lst, volumes_lst=volumes_lst
        ),
        *output_keys,
    )
```

EDIT: syntax highlighting

Again this change was initially introduced in https://github.com/pyiron/atomistics/pull/176 and is now moved to a separate pull request. 