### PR TITLE
Update pymace to 0.3.6

### DIFF
--- a/.ci_support/environment-mace.yml
+++ b/.ci_support/environment-mace.yml
@@ -1,4 +1,4 @@
 channels:
 - conda-forge
 dependencies:
-- pymace =0.3.4
+- pymace =0.3.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `pymace` dependency from version `0.3.4` to `0.3.6` to ensure compatibility and access to the latest features and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->