### PR TITLE
Add guide for potential installation

### DIFF
--- a/atomistics/calculators/lammps/potential.py
+++ b/atomistics/calculators/lammps/potential.py
@@ -6,6 +6,35 @@ import pandas
 from ase.atoms import Atoms
 
 
+potential_installation = """
+Potential installation guide:
+
+1. Check whether iprpy-data is installed. If not, install it using:
+
+`conda install -c conda-forge iprpy-data`
+
+2. Check whether the resource path is set via:
+
+```python
+import os
+print(os.environ["CONDA_PREFIX"])
+```
+
+3. If the resource path is set, you can call the potential using:
+
+```python
+from atomistics.calculators import get_potential_by_name
+
+
+get_potential_by_name(
+    potential_name=my_potential,
+    resource_path=os.path.join(os.environ["CONDA_PREFIX"], "share", "iprpy"),
+)
+```
+
+"""
+
+
 class PotentialAbstract(object):
     """
     The PotentialAbstract class loads a list of available potentials and sorts them. Afterwards the potentials can be
@@ -124,7 +153,7 @@ class PotentialAbstract(object):
                             ),
                         },
                     )
-        raise ValueError("Was not able to locate the potential files.")
+        raise ValueError("Was not able to locate the potential files." + potential_installation)
 
 
 class LammpsPotentialFile(PotentialAbstract):
@@ -310,7 +339,7 @@ def get_resource_path_from_conda(
             resource_path = os.path.join(env[conda_var], "share", "iprpy")
             if os.path.exists(resource_path):
                 return resource_path
-    raise ValueError("No resource_path found")
+    raise ValueError("No resource_path found" + potential_installation)
 
 
 def get_potential_dataframe(structure: Atoms, resource_path=None):

--- a/atomistics/calculators/lammps/potential.py
+++ b/atomistics/calculators/lammps/potential.py
@@ -5,7 +5,6 @@ from typing import Union
 import pandas
 from ase.atoms import Atoms
 
-
 potential_installation = """
 Potential installation guide:
 
@@ -153,7 +152,9 @@ class PotentialAbstract(object):
                             ),
                         },
                     )
-        raise ValueError("Was not able to locate the potential files." + potential_installation)
+        raise ValueError(
+            "Was not able to locate the potential files." + potential_installation
+        )
 
 
 class LammpsPotentialFile(PotentialAbstract):


### PR DESCRIPTION
Based on [this discussion](https://github.com/pyiron/atomistics/issues/319) I appended text to the error message. I guess @jan-janssen can update it to make it more accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a detailed installation guide for the potential module to assist users in setup.
  
- **Bug Fixes**
	- Enhanced error messages to include installation instructions when potential files cannot be located.

- **Usability Improvements**
	- Provided clear context and guidance directly within error messages to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->