### PR TITLE
Remove conda default channel

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,16 +17,14 @@ jobs:
         tail --lines=+4 .ci_support/environment-lammps.yml >> environment.yml
         tail --lines=+4 .ci_support/environment-qe.yml >> environment.yml
         sed -i 's/- scipy =1.13.0/- scipy =1.12.0/g' environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.11'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,14 +19,13 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: 3.11
-        mamba-version: "*"
-        channels: conda-forge
-        miniforge-variant: Mambaforge
-        channel-priority: strict
-        auto-update-conda: true
+        python-version: "3.12"
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment.yml
     - name: Convert dependencies
       run: |

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -10,16 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.12'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -16,16 +16,14 @@ jobs:
         run: |
           cp .ci_support/environment.yml environment.yml
           tail --lines=+4 .ci_support/environment-notebooks.yml >> environment.yml
+          echo -e "channels:\n  - conda-forge\n" > .condarc
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.12"
-          miniforge-variant: Mambaforge
-          channels: conda-forge
-          channel-priority: strict
-          activate-environment: my-env
+          miniforge-version: latest
+          condarc-file: .condarc
           environment-file: environment.yml
-          use-mamba: true
       - name: Test
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pypicheck.yml
+++ b/.github/workflows/pypicheck.yml
@@ -12,16 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.10'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        python-version: '3.12'
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment.yml
-        use-mamba: true
     - name: Pip check
       shell: bash -l {0}
       run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -37,16 +37,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-lammps.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,7 +30,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup environment (windows)
       if: matrix.operating-system == 'windows-latest'
-      run: cp .ci_support/environment.yml environment.yml
+      shell: bash -l {0}
+      run: |
+        cp .ci_support/environment.yml environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup environment (unix)
       if: matrix.operating-system != 'windows-latest'
       shell: bash -l {0}

--- a/.github/workflows/unittests_abinit.yml
+++ b/.github/workflows/unittests_abinit.yml
@@ -14,16 +14,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-abinit.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.12'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/unittests_gpaw.yml
+++ b/.github/workflows/unittests_gpaw.yml
@@ -14,16 +14,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-gpaw.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.12'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/unittests_mace.yml
+++ b/.github/workflows/unittests_mace.yml
@@ -14,16 +14,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-mace.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.12'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 60

--- a/.github/workflows/unittests_matgl.yml
+++ b/.github/workflows/unittests_matgl.yml
@@ -14,16 +14,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-matgl.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.11'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 60

--- a/.github/workflows/unittests_old.yml
+++ b/.github/workflows/unittests_old.yml
@@ -10,16 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.9'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment-old.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/unittests_qe.yml
+++ b/.github/workflows/unittests_qe.yml
@@ -14,16 +14,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-qe.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.11'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 60

--- a/.github/workflows/unittests_siesta.yml
+++ b/.github/workflows/unittests_siesta.yml
@@ -14,16 +14,14 @@ jobs:
       run: |
         cp .ci_support/environment.yml environment.yml
         tail --lines=+4 .ci_support/environment-siesta.yml >> environment.yml
+        echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.12'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: environment.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Conda environment setup across multiple workflows to use a new configuration file for specifying channels, enhancing maintainability.
	- Introduced a standardized approach for specifying the Mambaforge version as "latest."

- **Bug Fixes**
	- Fixed issues related to outdated parameters in the workflow configurations, ensuring the latest Conda practices are followed.

- **Documentation**
	- Improved clarity in CI workflow configurations by centralizing channel specifications in a `.condarc` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->