### PR TITLE
Use a single ProcessPoolExecutor

### DIFF
--- a/tests/test_evcurve_lammps_function_parallel.py
+++ b/tests/test_evcurve_lammps_function_parallel.py
@@ -37,14 +37,13 @@ class TestEvCurve(unittest.TestCase):
                 executor=exe,
                 potential_dataframe=df_pot_selected,
             )
-        structure_dict = generate_structures_helper(
-            structure=result_dict["structure_with_optimized_positions_and_volume"],
-            vol_range=0.05,
-            num_points=11,
-            strain_lst=None,
-            axes=("x", "y", "z"),
-        )
-        with ProcessPoolExecutor() as exe:
+            structure_dict = generate_structures_helper(
+                structure=result_dict["structure_with_optimized_positions_and_volume"],
+                vol_range=0.05,
+                num_points=11,
+                strain_lst=None,
+                axes=("x", "y", "z"),
+            )
             result_dict = evaluate_with_parallel_executor(
                 evaluate_function=evaluate_with_lammps,
                 task_dict={"calc_energy": structure_dict},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the efficiency and correctness of energy calculation tests by restructuring the execution context for generating structures.
- **Tests**
	- Enhanced the logical flow of the test execution for energy calculations using LAMMPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->