### PR TITLE
Update structuretoolkit to 0.0.29

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -12,7 +12,7 @@ dependencies:
 - scipy =1.14.1
 - spglib =2.5.0
 - phonopy =2.34.0
-- structuretoolkit =0.0.28
+- structuretoolkit =0.0.29
 - seekpath =2.1.0
 - lammps =2024.06.27
 - pandas =2.2.3

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -12,5 +12,5 @@ dependencies:
 - scipy =1.14.1
 - seekpath =2.1.0
 - spglib =2.5.0
-- structuretoolkit =0.0.28
+- structuretoolkit =0.0.29
 - tqdm =4.67.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - scipy =1.14.1
 - spglib =2.5.0
 - phonopy =2.34.0
-- structuretoolkit =0.0.28
+- structuretoolkit =0.0.29
 - seekpath =2.1.0
 - gpaw =24.6.0
 - lammps =2024.06.27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Repository = "https://github.com/pyiron/atomistics"
 phonopy = [
     "phonopy==2.34.0",
     "seekpath==2.1.0",
-    "structuretoolkit==0.0.28",
+    "structuretoolkit==0.0.29",
 ]
 gpaw = [
     "gpaw==24.6.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
  - Updated `structuretoolkit` package version from 0.0.28 to 0.0.29 across multiple configuration files:
    - `.ci_support/environment-docs.yml`
    - `.ci_support/environment.yml`
    - `binder/environment.yml`
    - `pyproject.toml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->