### PR TITLE
Update pylammpsmpit to 0.2.32

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -16,7 +16,7 @@ dependencies:
 - seekpath =2.1.0
 - lammps =2024.06.27
 - pandas =2.2.3
-- pylammpsmpi =0.2.31
+- pylammpsmpi =0.2.32
 - jinja2 =3.1.6
 - jupyter-book =1.0.0
 - pyiron_lammps =0.4.0

--- a/.ci_support/environment-lammps.yml
+++ b/.ci_support/environment-lammps.yml
@@ -4,7 +4,7 @@ dependencies:
 - lammps =2024.06.27=*openmpi*
 - openmpi =4.1.6
 - pandas =2.2.3
-- pylammpsmpi =0.2.31
+- pylammpsmpi =0.2.32
 - jinja2 =3.1.6
 - iprpy-data =2023.07.25
 - dynaphopy =1.17.16

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - gpaw =24.6.0
 - lammps =2024.06.27
 - pandas =2.2.3
-- pylammpsmpi =0.2.31
+- pylammpsmpi =0.2.32
 - jinja2 =3.1.6
 - dynaphopy =1.17.16
 - tqdm =4.67.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ lammps = [
     "pyiron_lammps==0.4.0",
 ]
 lammps_phonons = [
-    "pylammpsmpi==0.2.31",
+    "pylammpsmpi==0.2.32",
     "jinja2==3.1.6",
     "pandas==2.2.3",
     "dynaphopy==1.17.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ gpaw = [
     "gpaw==24.6.0",
 ]
 lammps = [
-    "pylammpsmpi==0.2.31",
+    "pylammpsmpi==0.2.32",
     "jinja2==3.1.6",
     "pandas==2.2.3",
     "pyiron_lammps==0.4.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the `pylammpsmpi` dependency version from 0.2.31 to 0.2.32 across multiple environment configurations, ensuring consistency with the latest package improvements.
  - Maintained the current versions for other dependencies to preserve existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->