### PR TITLE
Use semantikon annotation for units in a random number of functions

### DIFF
--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -22,3 +22,4 @@ dependencies:
 - pyiron_lammps =0.3.2
 - pyiron_vasp =0.2.4
 - sphinx_parser =0.0.1
+- semantikon =0.0.16

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -16,3 +16,4 @@ dependencies:
 - sphinx_parser =0.0.1
 - tqdm =4.67.1
 - pyiron_vasp =0.2.5
+- semantikon =0.0.16

--- a/atomistics/calculators/lammps/libcalculator.py
+++ b/atomistics/calculators/lammps/libcalculator.py
@@ -6,8 +6,8 @@ import numpy as np
 import pandas
 from jinja2 import Template
 from pylammpsmpi import LammpsASELibrary
-from semantikon.typing import u
 from semantikon.converter import units
+from semantikon.typing import u
 
 from atomistics.calculators.interface import get_quantities_from_tasks
 from atomistics.calculators.lammps.commands import (
@@ -146,6 +146,7 @@ def calc_static_with_lammpslib(
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
 
+
 @units
 def calc_molecular_dynamics_nvt_with_lammpslib(
     structure: Atoms,
@@ -199,6 +200,7 @@ def calc_molecular_dynamics_nvt_with_lammpslib(
     )
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
+
 
 @units
 def calc_molecular_dynamics_npt_with_lammpslib(
@@ -259,6 +261,7 @@ def calc_molecular_dynamics_npt_with_lammpslib(
     )
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
+
 
 @units
 def calc_molecular_dynamics_nph_with_lammpslib(

--- a/atomistics/calculators/lammps/libcalculator.py
+++ b/atomistics/calculators/lammps/libcalculator.py
@@ -42,12 +42,13 @@ if TYPE_CHECKING:
     from atomistics.calculators.interface import TaskName
 
 
+@units
 def optimize_positions_and_volume_with_lammpslib(
     structure: Atoms,
     potential_dataframe: DataFrame,
     min_style: str = "cg",
     etol: float = 0.0,
-    ftol: float = 0.0001,
+    ftol: u(float, units="eV/angstrom") = 0.0001,
     maxiter: int = 100000,
     maxeval: int = 10000000,
     thermo: int = 10,
@@ -84,6 +85,7 @@ def optimize_positions_and_volume_with_lammpslib(
     return structure_copy
 
 
+@units
 def optimize_positions_with_lammpslib(
     structure: Atoms,
     potential_dataframe: DataFrame,
@@ -96,7 +98,6 @@ def optimize_positions_with_lammpslib(
     lmp=None,
     **kwargs,
 ) -> Atoms:
-    print("Force", ftol)
     template_str = LAMMPS_THERMO_STYLE + "\n" + LAMMPS_THERMO + "\n" + LAMMPS_MINIMIZE
     lmp_instance = lammps_run(
         structure=structure,
@@ -145,16 +146,16 @@ def calc_static_with_lammpslib(
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
 
-
+@units
 def calc_molecular_dynamics_nvt_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
-    Tstart: float = 100.0,
-    Tstop: float = 100.0,
-    Tdamp: float = 0.1,
+    Tstart: u(float, units="kelvin") = 100.0,
+    Tstop: u(float, units="kelvin") = 100.0,
+    Tdamp: u(float, units="picosecond") = 0.1,
     run: int = 100,
     thermo: int = 10,
-    timestep: float = 0.001,
+    timestep: u(float, units="picosecond") = 0.001,
     seed: int = 4928459,
     dist: str = "gaussian",
     lmp=None,
@@ -199,19 +200,19 @@ def calc_molecular_dynamics_nvt_with_lammpslib(
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
 
-
+@units
 def calc_molecular_dynamics_npt_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
-    Tstart: float = 100.0,
-    Tstop: float = 100.0,
-    Tdamp: float = 0.1,
+    Tstart: u(float, units="kelvin") = 100.0,
+    Tstop: u(float, units="kelvin") = 100.0,
+    Tdamp: u(float, units="picosecond") = 0.1,
     run: int = 100,
     thermo: int = 100,
-    timestep: float = 0.001,
-    Pstart: float = 0.0,
-    Pstop: float = 0.0,
-    Pdamp: float = 1.0,
+    timestep: u(float, units="picosecond") = 0.001,
+    Pstart: u(float, units="bar") = 0.0,
+    Pstop: u(float, units="bar") = 0.0,
+    Pdamp: u(float, units="picosecond") = 1.0,
     seed: int = 4928459,
     dist: str = "gaussian",
     lmp=None,
@@ -259,17 +260,17 @@ def calc_molecular_dynamics_npt_with_lammpslib(
     lammps_shutdown(lmp_instance=lmp_instance, close_instance=lmp is None)
     return result_dict
 
-
+@units
 def calc_molecular_dynamics_nph_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
     run: int = 100,
     thermo: int = 100,
     timestep: float = 0.001,
-    Tstart: float = 100.0,
-    Pstart: float = 0.0,
-    Pstop: float = 0.0,
-    Pdamp: float = 1.0,
+    Tstart: u(float, units="kelvin") = 100.0,
+    Pstart: u(float, units="bar") = 0.0,
+    Pstop: u(float, units="bar") = 0.0,
+    Pdamp: u(float, units="picosecond") = 1.0,
     seed: int = 4928459,
     dist: str = "gaussian",
     lmp=None,
@@ -315,15 +316,16 @@ def calc_molecular_dynamics_nph_with_lammpslib(
     return result_dict
 
 
+@units
 def calc_molecular_dynamics_langevin_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
     run: int = 100,
     thermo: int = 100,
-    timestep: float = 0.001,
-    Tstart: float = 100.0,
-    Tstop: float = 100,
-    Tdamp: float = 0.1,
+    timestep: u(float, units="picosecond") = 0.001,
+    Tstart: u(float, units="kelvin") = 100.0,
+    Tstop: u(float, units="kelvin") = 100.0,
+    Tdamp: u(float, units="picosecond") = 0.1,
     seed: int = 4928459,
     dist: str = "gaussian",
     lmp=None,
@@ -372,19 +374,20 @@ def calc_molecular_dynamics_langevin_with_lammpslib(
     return result_dict
 
 
+@units
 def calc_molecular_dynamics_thermal_expansion_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
-    Tstart: float = 15.0,
-    Tstop: float = 1500.0,
+    Tstart: u(float, units="kelvin") = 15.0,
+    Tstop: u(float, units="kelvin") = 1500.0,
     Tstep: int = 5,
-    Tdamp: float = 0.1,
+    Tdamp: u(float, units="picosecond") = 0.1,
     run: int = 100,
     thermo: int = 100,
     timestep: float = 0.001,
-    Pstart: float = 0.0,
-    Pstop: float = 0.0,
-    Pdamp: float = 1.0,
+    Pstart: u(float, units="bar") = 0.0,
+    Pstop: u(float, units="bar") = 0.0,
+    Pdamp: u(float, units="picosecond") = 1.0,
     seed: int = 4928459,
     dist: str = "gaussian",
     lmp=None,

--- a/atomistics/calculators/lammps/libcalculator.py
+++ b/atomistics/calculators/lammps/libcalculator.py
@@ -335,7 +335,6 @@ def calc_molecular_dynamics_langevin_with_lammpslib(
     output_keys=OutputMolecularDynamics.keys(),
     **kwargs,
 ):
-    print("Force", timestep)
     init_str = (
         LAMMPS_THERMO_STYLE
         + "\n"

--- a/atomistics/calculators/lammps/libcalculator.py
+++ b/atomistics/calculators/lammps/libcalculator.py
@@ -7,7 +7,7 @@ import pandas
 from jinja2 import Template
 from pylammpsmpi import LammpsASELibrary
 from semantikon.typing import u
-from semantikon.converter import unit
+from semantikon.converter import units
 
 from atomistics.calculators.interface import get_quantities_from_tasks
 from atomistics.calculators.lammps.commands import (
@@ -89,13 +89,14 @@ def optimize_positions_with_lammpslib(
     potential_dataframe: DataFrame,
     min_style: str = "cg",
     etol: float = 0.0,
-    ftol: float = 0.0001,
+    ftol: u(float, units="eV/angstrom") = 0.0001,
     maxiter: int = 100000,
     maxeval: int = 10000000,
     thermo: int = 10,
     lmp=None,
     **kwargs,
 ) -> Atoms:
+    print("Force", ftol)
     template_str = LAMMPS_THERMO_STYLE + "\n" + LAMMPS_THERMO + "\n" + LAMMPS_MINIMIZE
     lmp_instance = lammps_run(
         structure=structure,
@@ -314,13 +315,12 @@ def calc_molecular_dynamics_nph_with_lammpslib(
     return result_dict
 
 
-@units
 def calc_molecular_dynamics_langevin_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
     run: int = 100,
     thermo: int = 100,
-    timestep: u(float, units="eV/angstrom") = 0.001,
+    timestep: float = 0.001,
     Tstart: float = 100.0,
     Tstop: float = 100,
     Tdamp: float = 0.1,

--- a/atomistics/calculators/lammps/libcalculator.py
+++ b/atomistics/calculators/lammps/libcalculator.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas
 from jinja2 import Template
 from pylammpsmpi import LammpsASELibrary
+from semantikon.typing import u
+from semantikon.converter import unit
 
 from atomistics.calculators.interface import get_quantities_from_tasks
 from atomistics.calculators.lammps.commands import (
@@ -312,12 +314,13 @@ def calc_molecular_dynamics_nph_with_lammpslib(
     return result_dict
 
 
+@units
 def calc_molecular_dynamics_langevin_with_lammpslib(
     structure: Atoms,
     potential_dataframe: pandas.DataFrame,
     run: int = 100,
     thermo: int = 100,
-    timestep: float = 0.001,
+    timestep: u(float, units="eV/angstrom") = 0.001,
     Tstart: float = 100.0,
     Tstop: float = 100,
     Tdamp: float = 0.1,
@@ -327,6 +330,7 @@ def calc_molecular_dynamics_langevin_with_lammpslib(
     output_keys=OutputMolecularDynamics.keys(),
     **kwargs,
 ):
+    print("Force", timestep)
     init_str = (
         LAMMPS_THERMO_STYLE
         + "\n"

--- a/atomistics/workflows/phonons/helper.py
+++ b/atomistics/workflows/phonons/helper.py
@@ -9,6 +9,9 @@ from phonopy import Phonopy
 from atomistics.shared.output import OutputPhonons, OutputThermodynamic
 from atomistics.workflows.phonons.units import VaspToTHz, kJ_mol_to_eV
 
+from semantikon.typing import u
+from semantikon.converter import units
+
 
 class PhonopyProperties:
     def __init__(
@@ -260,10 +263,11 @@ def restore_magmoms(
     return structure
 
 
+@units
 def generate_structures_helper(
     structure: Atoms,
     primitive_matrix: Optional[np.ndarray] = None,
-    displacement: float = 0.01,
+    displacement: u(float, units="angstrom") = 0.01,
     number_of_snapshots: Optional[int] = None,
     interaction_range: float = 10.0,
     factor: float = VaspToTHz,

--- a/atomistics/workflows/phonons/helper.py
+++ b/atomistics/workflows/phonons/helper.py
@@ -5,12 +5,11 @@ import scipy.constants
 import structuretoolkit
 from ase.atoms import Atoms
 from phonopy import Phonopy
+from semantikon.converter import units
+from semantikon.typing import u
 
 from atomistics.shared.output import OutputPhonons, OutputThermodynamic
 from atomistics.workflows.phonons.units import VaspToTHz, kJ_mol_to_eV
-
-from semantikon.typing import u
-from semantikon.converter import units
 
 
 class PhonopyProperties:


### PR DESCRIPTION
Following @jan-janssen's request, I opened this PR for the type annotations with units using [semantikon](https://github.com/pyiron/semantikon). I guess the fastest is to take a look at the actual code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced unit-aware handling for various calculation and helper functions, ensuring that physical quantities such as force tolerance, temperature, pressure, damping times, timestep, and displacement are now explicitly associated with their respective units.
- **Chores**
  - Added a new dependency to support unit-aware functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->