### PR TITLE
Update pyiron_vasp to 0.2.6

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -20,4 +20,4 @@ dependencies:
 - jinja2 =3.1.6
 - jupyter-book =1.0.0
 - pyiron_lammps =0.4.2
-- pyiron_vasp =0.2.5
+- pyiron_vasp =0.2.6

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -15,4 +15,4 @@ dependencies:
 - structuretoolkit =0.0.32
 - sphinx_parser =0.0.1
 - tqdm =4.67.1
-- pyiron_vasp =0.2.5
+- pyiron_vasp =0.2.6

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,4 +16,4 @@ dependencies:
 - dynaphopy =1.17.16
 - tqdm =4.67.1
 - pyiron_lammps =0.4.2
-- pyiron_vasp =0.2.5
+- pyiron_vasp =0.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ tqdm = [
     "tqdm==4.67.1"
 ]
 vasp = [
-    "pyiron_vasp==0.2.5"
+    "pyiron_vasp==0.2.6"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the required version of the pyiron_vasp package from 0.2.5 to 0.2.6 in all relevant configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->