### PR TITLE
Add SPHInX to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ simulation codes - named `calculators`. The supported simulation codes in alphab
 * [LAMMPS](https://www.lammps.org) - Molecular Dynamics
 * [Quantum Espresso](https://www.quantum-espresso.org) - Integrated suite of Open-Source computer codes for electronic-structure calculations
 * [Siesta](https://siesta-project.org) - Electronic structure calculations and ab initio molecular dynamics
+* [SPHInX](https://sxrepo.mpie.de) - Plane wave DFT with interactive tools, charged defect correction and spin constraints
 
 For majority of these simulation codes the `atomistics` package use the [Atomic Simulation Environment](https://wiki.fysik.dtu.dk/ase/)
 to interface the underlying C/ C++ and Fortran Codes with the Python programming language. Still this approach limits


### PR DESCRIPTION
I find the descriptions for the DFT tools confusing, because they look quite different from each other, even though they do mostly the same stuff. Besides just "Molecular Dynamics" for LAMMPS is just too short...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include SPHInX as a supported simulation code in the list of calculators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->