### PR TITLE
Update sphinx_parser to 0.0.2

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -13,6 +13,6 @@ dependencies:
 - seekpath =2.1.0
 - spglib =2.6.0
 - structuretoolkit =0.0.32
-- sphinx_parser =0.0.1
+- sphinx_parser =0.0.2
 - tqdm =4.67.1
 - pyiron_vasp =0.2.6

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -172,9 +172,6 @@ jobs:
         - operating-system: ubuntu-latest
           python-version: '3.11'
 
-        - operating-system: ubuntu-latest
-          python-version: '3.10'
-
     steps:
     - uses: actions/checkout@v4
     - name: Setup environment (windows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ experimental = [
     "requests==2.32.4",
 ]
 sphinxdft = [
-    "sphinx-parser==0.0.1"
+    "sphinx-parser==0.0.2"
 ]
 qe = [
     "pwtools==1.3.0"

--- a/tests/test_evcurve_sphinxdft.py
+++ b/tests/test_evcurve_sphinxdft.py
@@ -21,7 +21,7 @@ def validate_fitdict(fit_dict):
         fit_dict["bulkmodul_eq"] < 65,
         fit_dict["energy_eq"] > -227.72,
         fit_dict["energy_eq"] < -227.71,
-        fit_dict["volume_eq"] > 70.92,
+        fit_dict["volume_eq"] > 70.91,
         fit_dict["volume_eq"] < 70.93,
     ]
     if not all(lst):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the version of the sphinx-parser dependency from 0.0.1 to 0.0.2.
  * Adjusted testing workflows to remove Python 3.10 on Ubuntu from the test matrix.
  * Relaxed validation criteria for volume equilibrium to allow slightly smaller values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->