### PR TITLE
calculate phonons with grace as part of the tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -388,6 +388,7 @@ jobs:
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
         python -m unittest tests/test_ase_interface/test_evcurve_ase_grace.py
+        python -m unittest tests/test_ase_interface/test_phonons_ase_grace.py
 
   unittest_qe:
     needs: [black]

--- a/tests/test_ase_interface/test_phonons_ase_grace.py
+++ b/tests/test_ase_interface/test_phonons_ase_grace.py
@@ -1,0 +1,77 @@
+from ase.build import bulk
+from ase.optimize import LBFGS
+from phonopy.units import VaspToTHz
+import unittest
+
+from atomistics.calculators import evaluate_with_ase
+from atomistics.workflows import optimize_positions_and_volume, get_band_structure, get_dynamical_matrix, get_hesse_matrix, get_tasks_for_harmonic_approximation, analyse_results_for_harmonic_approximation
+
+
+try:
+    from tensorpotential.calculator import grace_fm
+
+    skip_grace_test = False
+except ImportError:
+    skip_grace_test = True
+
+
+@unittest.skipIf(
+    skip_grace_test, "grace is not installed, so the mace tests are skipped."
+)
+class TestPhonons(unittest.TestCase):
+    def test_calc_phonons(self):
+        structure = bulk("Al", cubic=True)
+        ase_calculator = grace_fm("GRACE-2L-OMAT")
+        task_dict = optimize_positions_and_volume(structure=structure)
+        result_dict = evaluate_with_ase(
+            task_dict=task_dict,
+            ase_calculator=ase_calculator,
+            ase_optimizer=LBFGS,
+            ase_optimizer_kwargs={"fmax": 0.001},
+        )
+        task_dict, phonopy_obj = get_tasks_for_harmonic_approximation(
+            structure=result_dict["structure_with_optimized_positions_and_volume"],
+            interaction_range=10,
+            factor=VaspToTHz,
+            displacement=0.01,
+            primitive_matrix=None,
+            number_of_snapshots=None,
+        )
+        result_dict = evaluate_with_ase(
+            task_dict=task_dict,
+            ase_calculator=ase_calculator,
+        )
+        phonopy_dict = analyse_results_for_harmonic_approximation(
+            phonopy=phonopy_obj,
+            output_dict=result_dict,
+            dos_mesh=20,
+        )
+        mesh_dict, dos_dict = phonopy_dict["mesh_dict"], phonopy_dict["total_dos_dict"]
+        self.assertEqual((324, 324), get_hesse_matrix(phonopy=phonopy_obj).shape)
+        self.assertTrue("qpoints" in mesh_dict.keys())
+        self.assertTrue("weights" in mesh_dict.keys())
+        self.assertTrue("frequencies" in mesh_dict.keys())
+        self.assertTrue("eigenvectors" in mesh_dict.keys())
+        self.assertTrue("group_velocities" in mesh_dict.keys())
+        self.assertTrue("frequency_points" in dos_dict.keys())
+        self.assertTrue("total_dos" in dos_dict.keys())
+        dynmat_shape = get_dynamical_matrix(phonopy=phonopy_obj).shape
+        self.assertEqual(dynmat_shape[0], 12)
+        self.assertEqual(dynmat_shape[1], 12)
+        hessmat_shape = get_hesse_matrix(phonopy=phonopy_obj).shape
+        self.assertEqual(hessmat_shape[0], 324)
+        self.assertEqual(hessmat_shape[1], 324)
+        band_dict = get_band_structure(phonopy=phonopy_obj, npoints=101)
+        self.assertEqual(len(band_dict['qpoints']), 6)
+        for vec in band_dict['qpoints']:
+            self.assertTrue(vec.shape[0] in [34, 39, 78, 101, 95])
+            self.assertEqual(vec.shape[1], 3)
+        self.assertEqual(len(band_dict['distances']), 6)
+        for vec in band_dict['distances']:
+            self.assertTrue(vec.shape[0] in [34, 39, 78, 101, 95])
+        self.assertEqual(len(band_dict['frequencies']), 6)
+        for vec in band_dict['frequencies']:
+            self.assertTrue(vec.shape[0] in [34, 39, 78, 101, 95])
+            self.assertEqual(vec.shape[1], 12)
+        self.assertIsNone(band_dict['eigenvectors'])
+        self.assertIsNone(band_dict['group_velocities'])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new unit tests to verify phonon calculations and related outputs using the `grace_fm` calculator in the phonon analysis workflow.
  * Expanded automated testing pipeline to include phonon calculation tests for improved validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->