### PR TITLE
Update pyiron_vasp to 0.2.10

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -19,6 +19,6 @@ dependencies:
 - jinja2 =3.1.6
 - jupyter-book =1.0.0
 - pyiron_lammps =0.4.5
-- pyiron_vasp =0.2.9
+- pyiron_vasp =0.2.10
 - hatchling =1.27.0
 - hatch-vcs =0.5.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -15,6 +15,6 @@ dependencies:
 - structuretoolkit =0.0.34
 - sphinx_parser =0.0.3
 - tqdm =4.67.1
-- pyiron_vasp =0.2.9
+- pyiron_vasp =0.2.10
 - hatchling =1.27.0
 - hatch-vcs =0.5.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,6 +16,6 @@ dependencies:
 - dynaphopy =1.17.16
 - tqdm =4.67.1
 - pyiron_lammps =0.4.5
-- pyiron_vasp =0.2.9
+- pyiron_vasp =0.2.10
 - hatchling =1.27.0
 - hatch-vcs =0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ tqdm = [
     "tqdm==4.67.1"
 ]
 vasp = [
-    "pyiron_vasp==0.2.9"
+    "pyiron_vasp==0.2.10"
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the pyiron_vasp dependency to version 0.2.10 across project configurations (documentation, CI, Binder, and optional VASP extras) to align with the latest patch release.
  - Ensures consistent environment setup across user and documentation builds.
  - No changes to user-facing functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->