### PR TITLE
Update pylammpsmpi to 0.3.0

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -15,7 +15,7 @@ dependencies:
 - seekpath =2.1.0
 - lammps =2024.06.27
 - pandas =2.3.2
-- pylammpsmpi =0.2.39
+- pylammpsmpi =0.3.0
 - jinja2 =3.1.6
 - jupyter-book =1.0.0
 - pyiron_lammps =0.4.6

--- a/.ci_support/environment-lammps.yml
+++ b/.ci_support/environment-lammps.yml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 dependencies:
 - lammps =2024.06.27=*openmpi*
-- openmpi =4.1.6
+- openmpi
 - pandas =2.3.2
 - pylammpsmpi =0.3.0
 - jinja2 =3.1.6

--- a/.ci_support/environment-lammps.yml
+++ b/.ci_support/environment-lammps.yml
@@ -4,7 +4,7 @@ dependencies:
 - lammps =2024.06.27=*openmpi*
 - openmpi =4.1.6
 - pandas =2.3.2
-- pylammpsmpi =0.2.39
+- pylammpsmpi =0.3.0
 - jinja2 =3.1.6
 - iprpy-data =2023.07.25
 - dynaphopy =1.17.16

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -6,7 +6,7 @@ dependencies:
 - gpaw =24.6.0
 - lammps =2024.06.27
 - pandas =2.3.2
-- pylammpsmpi =0.2.39
+- pylammpsmpi =0.3.0
 - jinja2 =3.1.6
 - dynaphopy =1.17.16=*_3
 - pyiron_lammps =0.4.6

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - coverage
 - lxml =6.0.1
 - mendeleev =0.19.0
+- mpi4py =4.0.1
 - numpy =1.26.4
 - pandas =2.3.2
 - phonopy =2.43.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - gpaw =24.6.0
 - lammps =2024.06.27
 - pandas =2.3.2
-- pylammpsmpi =0.2.39
+- pylammpsmpi =0.3.0
 - jinja2 =3.1.6
 - dynaphopy =1.17.16
 - tqdm =4.67.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,13 @@ gpaw = [
     "gpaw==24.6.0",
 ]
 lammps = [
-    "pylammpsmpi==0.2.39",
+    "pylammpsmpi==0.3.0",
     "jinja2==3.1.6",
     "pandas==2.3.2",
     "pyiron_lammps==0.4.6",
 ]
 lammps_phonons = [
-    "pylammpsmpi==0.2.39",
+    "pylammpsmpi==0.3.0",
     "jinja2==3.1.6",
     "pandas==2.3.2",
     "dynaphopy==1.17.16",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pylammpsmpi to 0.3.0 across environments and optional integrations (LAMMPS, phonons, docs, notebooks, Binder).
  * Added mpi4py 4.0.1 to CI environments.
  * Removed the explicit pin on OpenMPI to allow newer compatible versions.
  * These updates improve compatibility, stability, and access to upstream fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->