### PR TITLE
Update grace to 0.5.3 

### DIFF
--- a/.ci_support/environment-grace.yml
+++ b/.ci_support/environment-grace.yml
@@ -1,4 +1,4 @@
 channels:
 - conda-forge
 dependencies:
-- grace-tensorpotential =0.5.1
+- grace-tensorpotential =0.5.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the grace-tensorpotential dependency to 0.5.3 to align with the latest patch release.
  * Improves build reliability and compatibility in supported environments.
  * Incorporates minor upstream fixes and stability improvements.
  * No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->