### PR TITLE
Update scipy to 1.16.2

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -8,7 +8,7 @@ dependencies:
 - ase =3.26.0
 - coverage
 - numpy =2.3.3
-- scipy =1.15.2
+- scipy =1.12.2
 - spglib =2.6.0
 - phonopy =2.43.2
 - structuretoolkit =0.0.35

--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -8,7 +8,7 @@ dependencies:
 - ase =3.26.0
 - coverage
 - numpy =2.3.3
-- scipy =1.12.2
+- scipy =1.16.2
 - spglib =2.6.0
 - phonopy =2.43.2
 - structuretoolkit =0.0.35

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - pandas =2.3.2
 - phonopy =2.43.2
 - requests =2.32.5
-- scipy =1.15.2
+- scipy =1.16.2
 - seekpath =2.1.0
 - spglib =2.6.0
 - structuretoolkit =0.0.35

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,8 +2,8 @@ channels:
 - conda-forge
 dependencies:
 - ase =3.26.0
-- numpy =2.3.2
-- scipy =1.15.2
+- numpy =2.3.3
+- scipy =1.16.2
 - spglib =2.6.0
 - phonopy =2.43.2
 - structuretoolkit =0.0.35

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "ase==3.26.0",
     "numpy==2.3.3",
-    "scipy==1.15.2",
+    "scipy==1.16.2",
     "spglib==2.6.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SciPy to 1.16.2 across environments to improve compatibility, stability, and performance.
  * Updated NumPy to 2.3.3 in the interactive environment for better reliability and alignment with upstream releases.
  * General dependency refresh to ensure smoother setup and fewer environment conflicts.

* **Tests**
  * No functional changes; existing behavior remains the same, with updates focused on underlying dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->