### PR TITLE
Rephrase import warning because the messages are sometimes weird

### DIFF
--- a/src/atomistics/shared/import_warning.py
+++ b/src/atomistics/shared/import_warning.py
@@ -5,17 +5,15 @@ def raise_warning(module_list, import_error):
     if len(module_list) == 1:
         warnings.warn(
             message=module_list[0]
-            + "() is not available as the import of the"
-            + import_error.msg[2:]
-            + " failed.",
+            + "() is not available as the following import failed: "
+            + str(import_error),
             stacklevel=2,
         )
     else:
         error_msg = "(), ".join(module_list[:-1]) + "() and " + module_list[-1] + "()"
         warnings.warn(
             message=error_msg
-            + " are not available as the import of the"
-            + import_error.msg[2:]
-            + " failed.",
+            + " are not available as the following import failed: "
+            + str(import_error),
             stacklevel=2,
         )


### PR DESCRIPTION
Before:

... get_thermal_properties_for_quasi_harmonic_approximation(), plot_band_structure() and plot_dos() are not available as the import of thennot import name 'sph_harm' from 'scipy.special' ([/Users/waseda/miniforge3/envs/pyiron/lib/python3.14/site-packages/scipy/special/__init__.py](http://localhost:8888/Users/waseda/miniforge3/envs/pyiron/lib/python3.14/site-packages/scipy/special/__init__.py)) failed.

After:

... get_thermal_properties_for_quasi_harmonic_approximation(), plot_band_structure() and plot_dos() are not available as the following import failed: cannot import name 'sph_harm' from 'scipy.special' ([/Users/waseda/miniforge3/envs/pyiron/lib/python3.14/site-packages/scipy/special/__init__.py](http://localhost:8888/Users/waseda/miniforge3/envs/pyiron/lib/python3.14/site-packages/scipy/special/__init__.py))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import failure warning messages to display more accurate and complete error information when module imports fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyiron/atomistics/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->