### PR TITLE
Add pressure parameter

### DIFF
--- a/src/atomistics/calculators/lammps/commands.py
+++ b/src/atomistics/calculators/lammps/commands.py
@@ -14,9 +14,6 @@ min_style {{min_style}}
 minimize {{etol}} {{ftol}} {{maxiter}} {{maxeval}}"""
 
 
-LAMMPS_MINIMIZE_VOLUME = "fix ensemble all box/relax iso 0.0"
-
-
 LAMMPS_TIMESTEP = "timestep {{timestep}}"
 
 

--- a/src/atomistics/calculators/lammps/filecalculator.py
+++ b/src/atomistics/calculators/lammps/filecalculator.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Iterable, Optional
 
 import pandas
 from ase.atoms import Atoms
@@ -10,11 +10,11 @@ from lammpsparser import write_lammps_structure as _write_lammps_structure
 from atomistics.calculators.interface import get_quantities_from_tasks
 from atomistics.calculators.lammps.commands import (
     LAMMPS_MINIMIZE,
-    LAMMPS_MINIMIZE_VOLUME,
     LAMMPS_RUN,
     LAMMPS_THERMO,
     LAMMPS_THERMO_STYLE,
 )
+from atomistics.calculators.lammps.shared import get_box_relax_command
 from atomistics.calculators.wrapper import as_task_dict_evaluator
 from atomistics.shared.output import OutputStatic
 
@@ -90,10 +90,12 @@ def optimize_positions_and_volume_with_lammpsfile(
     maxiter: int = 100000,
     maxeval: int = 10000000,
     thermo: int = 10,
+    pressure: float | Iterable[float | None] = 0.0,
+    vmax: Optional[float] = None,
 ) -> Atoms:
     template_str = "\n".join(
         [
-            LAMMPS_MINIMIZE_VOLUME,
+            get_box_relax_command(pressure=pressure, vmax=vmax),
             LAMMPS_THERMO_STYLE,
             LAMMPS_THERMO,
             LAMMPS_MINIMIZE,

--- a/src/atomistics/calculators/lammps/libcalculator.py
+++ b/src/atomistics/calculators/lammps/libcalculator.py
@@ -27,6 +27,7 @@ from atomistics.calculators.lammps.helpers import (
     lammps_shutdown,
     lammps_thermal_expansion_loop,
 )
+from atomistics.calculators.lammps.shared import get_box_relax_command
 from atomistics.calculators.wrapper import as_task_dict_evaluator
 from atomistics.shared.output import OutputMolecularDynamics, OutputStatic
 from atomistics.shared.thermal_expansion import OutputThermalExpansion
@@ -55,7 +56,7 @@ def optimize_positions_and_volume_with_lammpslib(
 ) -> Atoms:
     template_str = "\n".join(
         [
-            _get_box_relax_command(pressure=pressure, vmax=vmax),
+            get_box_relax_command(pressure=pressure, vmax=vmax),
             LAMMPS_THERMO_STYLE,
             LAMMPS_THERMO,
             LAMMPS_MINIMIZE,
@@ -592,33 +593,3 @@ def evaluate_with_lammpslib(
     )
     lmp.close()
     return results_dict
-
-
-def _get_box_relax_command(
-    pressure: float | Iterable[float | None], vmax: Optional[float]
-) -> str:
-    if not isinstance(pressure, Iterable):
-        box_relax = f"fix ensemble all box/relax iso {pressure}"
-    elif len(pressure) == 3:
-        pressure_str = " ".join(
-            "{tag} {value}".format(tag=tag, value=value)
-            for tag, value in zip(["x", "y", "z"], pressure)
-            if value is not None
-        )
-        box_relax = f"fix ensemble all box/relax {pressure_str}"
-    elif len(pressure) == 6:
-        pressure_str = " ".join(
-            "{tag} {value}".format(tag=tag, value=value)
-            for tag, value in zip(["x", "y", "z", "xy", "xz", "yz"], pressure)
-            if value is not None
-        )
-        box_relax = f"fix ensemble all box/relax {pressure_str}"
-    else:
-        raise ValueError("pressure must be a float or an iterable of length 3 or 6.")
-    if vmax is not None:
-        if isinstance(vmax, float):
-            return box_relax + " vmax {vmax}".format(vmax=vmax)
-        else:
-            raise TypeError("vmax must be a float.")
-    else:
-        return box_relax

--- a/src/atomistics/calculators/lammps/libcalculator.py
+++ b/src/atomistics/calculators/lammps/libcalculator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Iterable
 
 import numpy as np
 import pandas
@@ -14,7 +14,6 @@ from atomistics.calculators.lammps.commands import (
     LAMMPS_ENSEMBLE_NVT,
     LAMMPS_LANGEVIN,
     LAMMPS_MINIMIZE,
-    LAMMPS_MINIMIZE_VOLUME,
     LAMMPS_NVE,
     LAMMPS_RUN,
     LAMMPS_THERMO,
@@ -49,13 +48,14 @@ def optimize_positions_and_volume_with_lammpslib(
     maxiter: int = 100000,
     maxeval: int = 10000000,
     thermo: int = 10,
+    pressure: float | Iterable[float | None] = 0.0,
     vmax: Optional[float] = None,
     lmp=None,
     **kwargs,
 ) -> Atoms:
     template_str = "\n".join(
         [
-            _get_vmax_command(vmax=vmax),
+            _get_vmax_command(pressure=pressure, vmax=vmax),
             LAMMPS_THERMO_STYLE,
             LAMMPS_THERMO,
             LAMMPS_MINIMIZE,
@@ -594,11 +594,31 @@ def evaluate_with_lammpslib(
     return results_dict
 
 
-def _get_vmax_command(vmax: Optional[float]) -> str:
+def _get_vmax_command(
+    pressure: float | Iterable[float | None], vmax: Optional[float]
+) -> str:
+    if not isinstance(pressure, Iterable):
+        box_relax = f"fix ensemble all box/relax iso {pressure}"
+    elif len(pressure) == 3:
+        pressure_str = " ".join(
+            "{tag} {value}".format(tag=tag, value=value)
+            for tag, value in zip(["x", "y", "z"], pressure)
+            if value is not None
+        )
+        box_relax = f"fix ensemble all box/relax {pressure_str}"
+    elif len(pressure) == 6:
+        pressure_str = " ".join(
+            "{tag} {value}".format(tag=tag, value=value)
+            for tag, value in zip(["x", "y", "z", "xy", "xz", "yz"], pressure)
+            if value is not None
+        )
+        box_relax = f"fix ensemble all box/relax {pressure_str}"
+    else:
+        raise ValueError("pressure must be a float or an iterable of length 3 or 6.")
     if vmax is not None:
         if isinstance(vmax, float):
-            return LAMMPS_MINIMIZE_VOLUME + " vmax {vmax}".format(vmax=vmax)
+            return box_relax + " vmax {vmax}".format(vmax=vmax)
         else:
             raise TypeError("vmax must be a float.")
     else:
-        return LAMMPS_MINIMIZE_VOLUME
+        return box_relax

--- a/src/atomistics/calculators/lammps/libcalculator.py
+++ b/src/atomistics/calculators/lammps/libcalculator.py
@@ -55,7 +55,7 @@ def optimize_positions_and_volume_with_lammpslib(
 ) -> Atoms:
     template_str = "\n".join(
         [
-            _get_vmax_command(pressure=pressure, vmax=vmax),
+            _get_box_relax_command(pressure=pressure, vmax=vmax),
             LAMMPS_THERMO_STYLE,
             LAMMPS_THERMO,
             LAMMPS_MINIMIZE,
@@ -594,7 +594,7 @@ def evaluate_with_lammpslib(
     return results_dict
 
 
-def _get_vmax_command(
+def _get_box_relax_command(
     pressure: float | Iterable[float | None], vmax: Optional[float]
 ) -> str:
     if not isinstance(pressure, Iterable):

--- a/src/atomistics/calculators/lammps/shared.py
+++ b/src/atomistics/calculators/lammps/shared.py
@@ -1,0 +1,31 @@
+from typing import Iterable, Optional
+
+
+def get_box_relax_command(
+    pressure: float | Iterable[float | None], vmax: Optional[float]
+) -> str:
+    if not isinstance(pressure, Iterable):
+        box_relax = f"fix ensemble all box/relax iso {pressure}"
+    elif len(pressure) == 3:
+        pressure_str = " ".join(
+            "{tag} {value}".format(tag=tag, value=value)
+            for tag, value in zip(["x", "y", "z"], pressure)
+            if value is not None
+        )
+        box_relax = f"fix ensemble all box/relax {pressure_str}"
+    elif len(pressure) == 6:
+        pressure_str = " ".join(
+            "{tag} {value}".format(tag=tag, value=value)
+            for tag, value in zip(["x", "y", "z", "xy", "xz", "yz"], pressure)
+            if value is not None
+        )
+        box_relax = f"fix ensemble all box/relax {pressure_str}"
+    else:
+        raise ValueError("pressure must be a float or an iterable of length 3 or 6.")
+    if vmax is not None:
+        if isinstance(vmax, float):
+            return box_relax + " vmax {vmax}".format(vmax=vmax)
+        else:
+            raise TypeError("vmax must be a float.")
+    else:
+        return box_relax

--- a/tests/test_lammps_vmax.py
+++ b/tests/test_lammps_vmax.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    from atomistics.calculators.lammps.libcalculator import _get_box_relax_command
+    from atomistics.calculators.lammps.shared import get_box_relax_command
 
     skip_lammps_test = False
 except ImportError:
@@ -13,27 +13,27 @@ except ImportError:
 )
 class TestGetVmaxCommand(unittest.TestCase):
     def test_pressure_float_vmax_none(self):
-        result = _get_box_relax_command(pressure=0.0, vmax=None)
+        result = get_box_relax_command(pressure=0.0, vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax iso 0.0")
 
     def test_pressure_float_vmax_float(self):
-        result = _get_box_relax_command(pressure=0.0, vmax=0.1)
+        result = get_box_relax_command(pressure=0.0, vmax=0.1)
         self.assertEqual(result, "fix ensemble all box/relax iso 0.0 vmax 0.1")
 
     def test_pressure_len_3(self):
-        result = _get_box_relax_command(pressure=[1.0, 2.0, 3.0], vmax=None)
+        result = get_box_relax_command(pressure=[1.0, 2.0, 3.0], vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0")
 
     def test_pressure_len_3_with_vmax(self):
-        result = _get_box_relax_command(pressure=[1.0, 2.0, 3.0], vmax=0.1)
+        result = get_box_relax_command(pressure=[1.0, 2.0, 3.0], vmax=0.1)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0 vmax 0.1")
 
     def test_pressure_len_3_with_none(self):
-        result = _get_box_relax_command(pressure=[1.0, None, 3.0], vmax=None)
+        result = get_box_relax_command(pressure=[1.0, None, 3.0], vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 z 3.0")
 
     def test_pressure_len_6(self):
-        result = _get_box_relax_command(
+        result = get_box_relax_command(
             pressure=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vmax=None
         )
         self.assertEqual(
@@ -41,7 +41,7 @@ class TestGetVmaxCommand(unittest.TestCase):
         )
 
     def test_pressure_len_6_with_vmax(self):
-        result = _get_box_relax_command(
+        result = get_box_relax_command(
             pressure=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vmax=0.1
         )
         self.assertEqual(
@@ -51,19 +51,19 @@ class TestGetVmaxCommand(unittest.TestCase):
 
     def test_pressure_invalid_len_raises_value_error(self):
         with self.assertRaises(ValueError):
-            _get_box_relax_command(pressure=[1.0, 2.0], vmax=None)
+            get_box_relax_command(pressure=[1.0, 2.0], vmax=None)
 
     def test_pressure_additional_invalid_lens_raise_value_error(self):
         invalid_pressures = [[], [1.0, 2.0, 3.0, 4.0], [1.0] * 5, [1.0] * 7]
         for pressure in invalid_pressures:
             with self.subTest(pressure=pressure):
                 with self.assertRaises(ValueError):
-                    _get_box_relax_command(pressure=pressure, vmax=None)
+                    get_box_relax_command(pressure=pressure, vmax=None)
 
     def test_vmax_integer_raises_type_error(self):
         with self.assertRaises(TypeError):
-            _get_box_relax_command(pressure=0.0, vmax=1)
+            get_box_relax_command(pressure=0.0, vmax=1)
 
     def test_vmax_string_raises_type_error(self):
         with self.assertRaises(TypeError):
-            _get_box_relax_command(pressure=0.0, vmax="0.1")
+            get_box_relax_command(pressure=0.0, vmax="0.1")

--- a/tests/test_lammps_vmax.py
+++ b/tests/test_lammps_vmax.py
@@ -24,6 +24,10 @@ class TestGetVmaxCommand(unittest.TestCase):
         result = _get_vmax_command(pressure=[1.0, 2.0, 3.0], vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0")
 
+    def test_pressure_len_3_with_vmax(self):
+        result = _get_vmax_command(pressure=[1.0, 2.0, 3.0], vmax=0.1)
+        self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0 vmax 0.1")
+
     def test_pressure_len_3_with_none(self):
         result = _get_vmax_command(pressure=[1.0, None, 3.0], vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 z 3.0")
@@ -36,9 +40,25 @@ class TestGetVmaxCommand(unittest.TestCase):
             result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0 xy 4.0 xz 5.0 yz 6.0"
         )
 
+    def test_pressure_len_6_with_vmax(self):
+        result = _get_vmax_command(
+            pressure=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vmax=0.1
+        )
+        self.assertEqual(
+            result,
+            "fix ensemble all box/relax x 1.0 y 2.0 z 3.0 xy 4.0 xz 5.0 yz 6.0 vmax 0.1",
+        )
+
     def test_pressure_invalid_len_raises_value_error(self):
         with self.assertRaises(ValueError):
             _get_vmax_command(pressure=[1.0, 2.0], vmax=None)
+
+    def test_pressure_additional_invalid_lens_raise_value_error(self):
+        invalid_pressures = [[], [1.0, 2.0, 3.0, 4.0], [1.0] * 5, [1.0] * 7]
+        for pressure in invalid_pressures:
+            with self.subTest(pressure=pressure):
+                with self.assertRaises(ValueError):
+                    _get_vmax_command(pressure=pressure, vmax=None)
 
     def test_vmax_integer_raises_type_error(self):
         with self.assertRaises(TypeError):

--- a/tests/test_lammps_vmax.py
+++ b/tests/test_lammps_vmax.py
@@ -1,7 +1,6 @@
 import unittest
 
 try:
-    from atomistics.calculators.lammps.commands import LAMMPS_MINIMIZE_VOLUME
     from atomistics.calculators.lammps.libcalculator import _get_vmax_command
 
     skip_lammps_test = False
@@ -13,22 +12,38 @@ except ImportError:
     skip_lammps_test, "LAMMPS is not installed, so the LAMMPS tests are skipped."
 )
 class TestGetVmaxCommand(unittest.TestCase):
-    def test_vmax_none_returns_minimize_volume(self):
-        result = _get_vmax_command(vmax=None)
-        self.assertEqual(result, LAMMPS_MINIMIZE_VOLUME)
+    def test_pressure_float_vmax_none(self):
+        result = _get_vmax_command(pressure=0.0, vmax=None)
+        self.assertEqual(result, "fix ensemble all box/relax iso 0.0")
 
-    def test_vmax_float_appends_vmax(self):
-        result = _get_vmax_command(vmax=0.1)
-        self.assertEqual(result, LAMMPS_MINIMIZE_VOLUME + " vmax 0.1")
+    def test_pressure_float_vmax_float(self):
+        result = _get_vmax_command(pressure=0.0, vmax=0.1)
+        self.assertEqual(result, "fix ensemble all box/relax iso 0.0 vmax 0.1")
 
-    def test_vmax_float_zero_appends_vmax(self):
-        result = _get_vmax_command(vmax=0.0)
-        self.assertEqual(result, LAMMPS_MINIMIZE_VOLUME + " vmax 0.0")
+    def test_pressure_len_3(self):
+        result = _get_vmax_command(pressure=[1.0, 2.0, 3.0], vmax=None)
+        self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0")
+
+    def test_pressure_len_3_with_none(self):
+        result = _get_vmax_command(pressure=[1.0, None, 3.0], vmax=None)
+        self.assertEqual(result, "fix ensemble all box/relax x 1.0 z 3.0")
+
+    def test_pressure_len_6(self):
+        result = _get_vmax_command(
+            pressure=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vmax=None
+        )
+        self.assertEqual(
+            result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0 xy 4.0 xz 5.0 yz 6.0"
+        )
+
+    def test_pressure_invalid_len_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _get_vmax_command(pressure=[1.0, 2.0], vmax=None)
 
     def test_vmax_integer_raises_type_error(self):
         with self.assertRaises(TypeError):
-            _get_vmax_command(vmax=1)
+            _get_vmax_command(pressure=0.0, vmax=1)
 
     def test_vmax_string_raises_type_error(self):
         with self.assertRaises(TypeError):
-            _get_vmax_command(vmax="0.1")
+            _get_vmax_command(pressure=0.0, vmax="0.1")

--- a/tests/test_lammps_vmax.py
+++ b/tests/test_lammps_vmax.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    from atomistics.calculators.lammps.libcalculator import _get_vmax_command
+    from atomistics.calculators.lammps.libcalculator import _get_box_relax_command
 
     skip_lammps_test = False
 except ImportError:
@@ -13,27 +13,27 @@ except ImportError:
 )
 class TestGetVmaxCommand(unittest.TestCase):
     def test_pressure_float_vmax_none(self):
-        result = _get_vmax_command(pressure=0.0, vmax=None)
+        result = _get_box_relax_command(pressure=0.0, vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax iso 0.0")
 
     def test_pressure_float_vmax_float(self):
-        result = _get_vmax_command(pressure=0.0, vmax=0.1)
+        result = _get_box_relax_command(pressure=0.0, vmax=0.1)
         self.assertEqual(result, "fix ensemble all box/relax iso 0.0 vmax 0.1")
 
     def test_pressure_len_3(self):
-        result = _get_vmax_command(pressure=[1.0, 2.0, 3.0], vmax=None)
+        result = _get_box_relax_command(pressure=[1.0, 2.0, 3.0], vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0")
 
     def test_pressure_len_3_with_vmax(self):
-        result = _get_vmax_command(pressure=[1.0, 2.0, 3.0], vmax=0.1)
+        result = _get_box_relax_command(pressure=[1.0, 2.0, 3.0], vmax=0.1)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 y 2.0 z 3.0 vmax 0.1")
 
     def test_pressure_len_3_with_none(self):
-        result = _get_vmax_command(pressure=[1.0, None, 3.0], vmax=None)
+        result = _get_box_relax_command(pressure=[1.0, None, 3.0], vmax=None)
         self.assertEqual(result, "fix ensemble all box/relax x 1.0 z 3.0")
 
     def test_pressure_len_6(self):
-        result = _get_vmax_command(
+        result = _get_box_relax_command(
             pressure=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vmax=None
         )
         self.assertEqual(
@@ -41,7 +41,7 @@ class TestGetVmaxCommand(unittest.TestCase):
         )
 
     def test_pressure_len_6_with_vmax(self):
-        result = _get_vmax_command(
+        result = _get_box_relax_command(
             pressure=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vmax=0.1
         )
         self.assertEqual(
@@ -51,19 +51,19 @@ class TestGetVmaxCommand(unittest.TestCase):
 
     def test_pressure_invalid_len_raises_value_error(self):
         with self.assertRaises(ValueError):
-            _get_vmax_command(pressure=[1.0, 2.0], vmax=None)
+            _get_box_relax_command(pressure=[1.0, 2.0], vmax=None)
 
     def test_pressure_additional_invalid_lens_raise_value_error(self):
         invalid_pressures = [[], [1.0, 2.0, 3.0, 4.0], [1.0] * 5, [1.0] * 7]
         for pressure in invalid_pressures:
             with self.subTest(pressure=pressure):
                 with self.assertRaises(ValueError):
-                    _get_vmax_command(pressure=pressure, vmax=None)
+                    _get_box_relax_command(pressure=pressure, vmax=None)
 
     def test_vmax_integer_raises_type_error(self):
         with self.assertRaises(TypeError):
-            _get_vmax_command(pressure=0.0, vmax=1)
+            _get_box_relax_command(pressure=0.0, vmax=1)
 
     def test_vmax_string_raises_type_error(self):
         with self.assertRaises(TypeError):
-            _get_vmax_command(pressure=0.0, vmax="0.1")
+            _get_box_relax_command(pressure=0.0, vmax="0.1")


### PR DESCRIPTION
This pull request refactors how pressure and box relaxation are handled in LAMMPS minimization routines. The main improvement is the replacement of the fixed `LAMMPS_MINIMIZE_VOLUME` command with a more flexible system that allows specifying pressure as a scalar or an iterable for anisotropic relaxation. The `_get_vmax_command` function and its usage are updated accordingly.

**Refactoring and flexibility improvements:**

* Replaced the static `LAMMPS_MINIMIZE_VOLUME` command with dynamic generation of the box relaxation command in `_get_vmax_command`, allowing pressure to be specified as a float (isotropic) or as an iterable of length 3 or 6 (anisotropic), improving flexibility for different simulation setups. [[1]](diffhunk://#diff-0c64e22007499b253efea7c21dabf4592042419b64479d1ad0c2c352aab0615fR51-R58) [[2]](diffhunk://#diff-0c64e22007499b253efea7c21dabf4592042419b64479d1ad0c2c352aab0615fL597-R624)
* Updated the signature of `optimize_positions_and_volume_with_lammpslib` to accept a `pressure` argument (float or iterable), and passed it to `_get_vmax_command`.
* Removed the now-unused `LAMMPS_MINIMIZE_VOLUME` constant from both `commands.py` and the import list in `libcalculator.py`. [[1]](diffhunk://#diff-e3dc0757f9a2f4ff89ecc86aad82189b39ca58f39844960ecca549058283cd03L17-L19) [[2]](diffhunk://#diff-0c64e22007499b253efea7c21dabf4592042419b64479d1ad0c2c352aab0615fL17)

**Type hinting and code clarity:**

* Added `Iterable` to the imports in `libcalculator.py` to support the new type hints for the `pressure` argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pressure-dependent control for box relaxation during position and volume optimization; accepts scalar or iterable pressures and an optional vmax to constrain cell relaxation.
* **Tests**
  * Updated unit tests covering various pressure shapes, vmax handling, and related error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyiron/atomistics/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->