### PR TITLE
Add and extend docstrings across src/atomistics

### DIFF
--- a/src/atomistics/calculators/interface.py
+++ b/src/atomistics/calculators/interface.py
@@ -15,6 +15,8 @@ else:
 
 
 class TaskEnum(StrEnum):
+    """Enumeration of supported calculator tasks."""
+
     calc_energy = "calc_energy"
     calc_forces = "calc_forces"
     calc_stress = "calc_stress"
@@ -28,6 +30,8 @@ class TaskEnum(StrEnum):
 
 
 class TaskOutputEnum(Enum):
+    """Maps task names to their corresponding output key names."""
+
     energy = "calc_energy"
     forces = "calc_forces"
     stress = "calc_stress"

--- a/src/atomistics/calculators/lammps/filecalculator.py
+++ b/src/atomistics/calculators/lammps/filecalculator.py
@@ -26,23 +26,47 @@ DUMP_COMMANDS = [
 
 
 class GenericOutput:
+    """Accessor for parsed LAMMPS file-calculator output.
+
+    Args:
+        output_dict (dict[str, Any]): Parsed output dictionary returned by
+            ``lammpsparser.parse_lammps_output_files``.
+    """
+
     def __init__(self, output_dict: dict[str, Any]):
         self._output_dict = output_dict
 
     def get_forces(self) -> list[list[float]]:
+        """Return atomic forces from the last recorded frame in eV/Å."""
         return self._output_dict["generic"]["forces"][-1]
 
     def get_energy_pot(self) -> float:
+        """Return the potential energy from the last recorded frame in eV."""
         return self._output_dict["generic"]["energy_pot"][-1]
 
     def get_stress(self) -> list[float]:
+        """Return the pressure tensor from the last recorded frame in GPa."""
         return self._output_dict["generic"]["pressures"][-1]
 
     def get_volume(self) -> float:
+        """Return the cell volume from the last recorded frame in Å³."""
         return self._output_dict["generic"]["volume"][-1]
 
 
 def _lammps_file_initialization(structure: Atoms) -> list[str]:
+    """
+    Generate the header LAMMPS input commands for a metal-units simulation.
+
+    Sets up units, dimension, periodic boundary flags (derived from ``structure.pbc``),
+    atom style, and reads in the structure data file.
+
+    Args:
+        structure (Atoms): The ASE structure whose PBC flags determine the boundary conditions.
+
+    Returns:
+        list[str]: LAMMPS input command strings (each ending with ``\\n``) to be written
+            at the top of an input file.
+    """
     dimension = 3
     boundary = " ".join(["p" if coord else "f" for coord in structure.pbc])
     init_commands = [
@@ -61,6 +85,19 @@ def _write_lammps_input_file(
     potential_dataframe: pandas.DataFrame,
     input_template: str,
 ) -> None:
+    """
+    Write the LAMMPS structure data file and input script to ``working_directory``.
+
+    The structure is written as ``lammps.data`` and the input script as ``lmp.in``.
+    The script is assembled from the initialisation commands, the potential ``Config``
+    lines, the dump commands, and the rendered ``input_template``.
+
+    Args:
+        working_directory (str): Directory in which to write the LAMMPS input files.
+        structure (Atoms): The ASE structure to write.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        input_template (str): Pre-rendered LAMMPS commands appended after the potential section.
+    """
     _write_lammps_structure(
         structure=structure,
         potential_elements=potential_dataframe["Species"],
@@ -94,6 +131,29 @@ def optimize_positions_and_volume_with_lammpsfile(
     pressure: float | Iterable[float | None] = 0.0,
     vmax: Optional[float] = None,
 ) -> Atoms:
+    """
+    Relax atomic positions and cell with LAMMPS using file-based I/O.
+
+    Writes LAMMPS input files, executes the calculator, parses the output, and
+    returns a structure with the relaxed positions and cell.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        working_directory (str): Directory for LAMMPS input/output files.
+        executable_function (Callable[[str], Any]): Callable that runs LAMMPS in the given directory.
+        min_style (str): LAMMPS minimisation style (e.g. ``"cg"``). Defaults to ``"cg"``.
+        etol (float): Energy tolerance for minimisation. Defaults to ``0.0``.
+        ftol (float): Force tolerance for minimisation in eV/Å. Defaults to ``0.0001``.
+        maxiter (int): Maximum number of minimisation iterations. Defaults to ``100000``.
+        maxeval (int): Maximum number of force evaluations. Defaults to ``10000000``.
+        thermo (int): Thermo output frequency. Defaults to ``10``.
+        pressure (float | Iterable[float | None]): Target pressure for ``box/relax`` in bar.
+        vmax (float | None): Maximum fractional volume change per step for ``box/relax``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed positions and cell.
+    """
     template_str = "\n".join(
         [
             get_box_relax_command(pressure=pressure, vmax=vmax),
@@ -145,6 +205,24 @@ def optimize_positions_with_lammpsfile(
     maxeval: int = 10000000,
     thermo: int = 10,
 ) -> Atoms:
+    """
+    Relax atomic positions with LAMMPS using file-based I/O (cell fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        working_directory (str): Directory for LAMMPS input/output files.
+        executable_function (Callable[[str], Any]): Callable that runs LAMMPS in the given directory.
+        min_style (str): LAMMPS minimisation style. Defaults to ``"cg"``.
+        etol (float): Energy tolerance for minimisation. Defaults to ``0.0``.
+        ftol (float): Force tolerance for minimisation in eV/Å. Defaults to ``0.0001``.
+        maxiter (int): Maximum number of minimisation iterations. Defaults to ``100000``.
+        maxeval (int): Maximum number of force evaluations. Defaults to ``10000000``.
+        thermo (int): Thermo output frequency. Defaults to ``10``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed atomic positions.
+    """
     template_str = "\n".join([LAMMPS_THERMO_STYLE, LAMMPS_THERMO, LAMMPS_MINIMIZE])
     input_template = Template(template_str).render(
         min_style=min_style,
@@ -183,6 +261,19 @@ def calc_static_with_lammpsfile(
     executable_function: Callable[[str], Any],
     output_keys=OutputStatic.keys(),
 ) -> dict[str, Any]:
+    """
+    Run a static LAMMPS calculation using file-based I/O and return the requested output.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        working_directory (str): Directory for LAMMPS input/output files.
+        executable_function (Callable[[str], Any]): Callable that runs LAMMPS in the given directory.
+        output_keys: Which output quantities to return. Defaults to all ``OutputStatic`` keys.
+
+    Returns:
+        dict[str, Any]: Requested output quantities keyed by name.
+    """
     template_str = "\n".join([LAMMPS_THERMO_STYLE, LAMMPS_THERMO, LAMMPS_RUN])
     input_template = Template(template_str).render(
         run=0,
@@ -224,6 +315,27 @@ def evaluate_with_lammpsfile(
     executable_function: Callable[[str], Any],
     lmp_optimizer_kwargs: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
+    """
+    Evaluate a task dictionary using LAMMPS file-based I/O and return results for all tasks.
+
+    Dispatches to the appropriate file-calculator function based on the requested tasks.
+    Decorated with ``as_task_dict_evaluator``.
+
+    Args:
+        structure (Atoms): The input structure.
+        tasks (list[str]): List of task name strings.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        working_directory (str): Directory for LAMMPS input/output files.
+        executable_function (Callable[[str], Any]): Callable that runs LAMMPS in the given directory.
+        lmp_optimizer_kwargs (dict[str, Any] | None): Extra keyword arguments forwarded to the
+            underlying optimisation or static functions.
+
+    Returns:
+        dict[str, Any]: Results keyed by output quantity name.
+
+    Raises:
+        ValueError: If none of the requested tasks are implemented by this calculator.
+    """
     if lmp_optimizer_kwargs is None:
         lmp_optimizer_kwargs = {}
     results: dict[str, Any] = {}

--- a/src/atomistics/calculators/lammps/helpers.py
+++ b/src/atomistics/calculators/lammps/helpers.py
@@ -22,6 +22,27 @@ def lammps_run(
     lmp: LammpsASELibrary | None = None,
     **kwargs,
 ) -> LammpsASELibrary:
+    """
+    Initialise a LAMMPS instance, load the structure and potential, and run an input template.
+
+    If no ``lmp`` instance is provided a new one is created using ``**kwargs``.
+    The structure is written to LAMMPS via the interactive interface, the potential
+    commands are applied, and each line of ``input_template`` is sent as a library command.
+
+    Args:
+        structure (Atoms): The ASE structure to load into LAMMPS.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns
+            describing the interatomic potential.
+        input_template (str | None): Multi-line string of LAMMPS commands to execute after loading
+            the structure and potential. No commands are sent if ``None``.
+        lmp (LammpsASELibrary | None): An existing LAMMPS library instance to reuse.
+            A new instance is created if ``None``.
+        **kwargs: Additional keyword arguments forwarded to ``LammpsASELibrary`` when creating
+            a new instance.
+
+    Returns:
+        LammpsASELibrary: The LAMMPS library instance after executing all commands.
+    """
     potential_dataframe = validate_potential_dataframe(
         potential_dataframe=potential_dataframe
     )
@@ -56,6 +77,21 @@ def lammps_calc_md_step(
     run: int,
     output_keys: Iterable[str] = OutputMolecularDynamics.keys(),
 ) -> dict:
+    """
+    Execute a single MD run segment and collect output quantities.
+
+    Renders ``run_str`` with the given ``run`` count, sends it to the LAMMPS instance,
+    and queries the instance for all requested output quantities.
+
+    Args:
+        lmp_instance (LammpsASELibrary): An active LAMMPS library instance.
+        run_str (str): Jinja2 template string for the LAMMPS ``run`` command (receives ``run``).
+        run (int): Number of timesteps to advance in this segment.
+        output_keys (Iterable[str]): Names of the output quantities to collect.
+
+    Returns:
+        dict: Collected output quantities for this MD segment keyed by quantity name.
+    """
     run_str_rendered = Template(run_str).render(run=run)
     lmp_instance.interactive_lib_command(run_str_rendered)
     return OutputMolecularDynamics(
@@ -77,7 +113,23 @@ def lammps_calc_md(
     run: int,
     thermo: int,
     output_keys: Iterable[str] = OutputMolecularDynamics.keys(),
-):
+) -> dict:
+    """
+    Run a full MD simulation by collecting output every ``thermo`` steps.
+
+    Calls ``lammps_calc_md_step`` ``run // thermo`` times, each advancing ``thermo``
+    timesteps, and stacks the per-step results into numpy arrays.
+
+    Args:
+        lmp_instance (LammpsASELibrary): An active LAMMPS library instance.
+        run_str (str): Jinja2 template string for the LAMMPS ``run`` command (receives ``run``).
+        run (int): Total number of MD timesteps to execute.
+        thermo (int): Number of timesteps between output snapshots.
+        output_keys (Iterable[str]): Names of the output quantities to collect.
+
+    Returns:
+        dict: Output quantities as numpy arrays with one entry per snapshot, keyed by quantity name.
+    """
     results_lst = [
         lammps_calc_md_step(
             lmp_instance=lmp_instance,
@@ -110,6 +162,36 @@ def lammps_thermal_expansion_loop(
     output_keys=OutputThermalExpansion.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run NPT molecular dynamics at a sequence of temperatures to compute thermal expansion.
+
+    Initialises a LAMMPS simulation once using ``init_str`` and then iterates through
+    ``temperature_lst``, running ``run`` steps at each temperature via ``run_str``.
+    The equilibrium volume and temperature are recorded after each segment.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        init_str (str): Jinja2 template for the LAMMPS initialisation commands (thermostat setup etc.).
+        run_str (str): Jinja2 template for the per-temperature run commands.
+        temperature_lst (list[float]): Ordered list of target temperatures in K.
+        run (int): Number of MD timesteps per temperature point. Defaults to ``100``.
+        thermo (int): Thermo output frequency in timesteps. Defaults to ``100``.
+        timestep (float): MD timestep in ps. Defaults to ``0.001``.
+        Tdamp (float): Thermostat damping parameter in ps. Defaults to ``0.1``.
+        Pstart (float): Starting pressure in bar. Defaults to ``0.0``.
+        Pstop (float): Ending pressure in bar. Defaults to ``0.0``.
+        Pdamp (float): Barostat damping parameter in ps. Defaults to ``1.0``.
+        seed (int): Random seed for velocity initialisation. Defaults to ``4928459``.
+        dist (str): Velocity distribution type (``"gaussian"`` or ``"uniform"``). Defaults to ``"gaussian"``.
+        velocity_rescale_factor (float): Scaling factor applied during velocity initialisation. Defaults to ``2.0``.
+        lmp: Existing LAMMPS instance to reuse. A new instance is created if ``None``.
+        output_keys: Output quantities to return. Defaults to all ``OutputThermalExpansion`` keys.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        dict: Thermal expansion output quantities (temperatures and volumes) keyed by name.
+    """
     lmp_instance = lammps_run(
         structure=structure,
         potential_dataframe=potential_dataframe,
@@ -151,6 +233,14 @@ def lammps_thermal_expansion_loop(
 def lammps_shutdown(
     lmp_instance: LammpsASELibrary, close_instance: bool = True
 ) -> None:
+    """
+    Issue a ``clear`` command to the LAMMPS instance and optionally close it.
+
+    Args:
+        lmp_instance (LammpsASELibrary): The active LAMMPS library instance to shut down.
+        close_instance (bool): Whether to call ``lmp_instance.close()`` after clearing.
+            Set to ``False`` when the caller manages the instance lifetime. Defaults to ``True``.
+    """
     lmp_instance.interactive_lib_command("clear")
     if close_instance:
         lmp_instance.close()

--- a/src/atomistics/calculators/lammps/libcalculator.py
+++ b/src/atomistics/calculators/lammps/libcalculator.py
@@ -55,6 +55,26 @@ def optimize_positions_and_volume_with_lammpslib(
     lmp=None,
     **kwargs,
 ) -> Atoms:
+    """
+    Relax atomic positions and cell using the LAMMPS library interface.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        min_style (str): LAMMPS minimisation style. Defaults to ``"cg"``.
+        etol (float): Energy tolerance for minimisation. Defaults to ``0.0``.
+        ftol (float): Force tolerance in eV/Å. Defaults to ``0.0001``.
+        maxiter (int): Maximum number of minimisation iterations. Defaults to ``100000``.
+        maxeval (int): Maximum number of force evaluations. Defaults to ``10000000``.
+        thermo (int): Thermo output frequency. Defaults to ``10``.
+        pressure (float | Iterable[float | None]): Target pressure for ``box/relax`` in bar.
+        vmax (float | None): Maximum fractional volume change per step for ``box/relax``.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed positions and cell.
+    """
     template_str = "\n".join(
         [
             get_box_relax_command(pressure=pressure, vmax=vmax),
@@ -96,6 +116,24 @@ def optimize_positions_with_lammpslib(
     lmp=None,
     **kwargs,
 ) -> Atoms:
+    """
+    Relax atomic positions using the LAMMPS library interface (cell fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        min_style (str): LAMMPS minimisation style. Defaults to ``"cg"``.
+        etol (float): Energy tolerance for minimisation. Defaults to ``0.0``.
+        ftol (float): Force tolerance in eV/Å. Defaults to ``0.0001``.
+        maxiter (int): Maximum number of minimisation iterations. Defaults to ``100000``.
+        maxeval (int): Maximum number of force evaluations. Defaults to ``10000000``.
+        thermo (int): Thermo output frequency. Defaults to ``10``.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed atomic positions.
+    """
     template_str = "\n".join([LAMMPS_THERMO_STYLE, LAMMPS_THERMO, LAMMPS_MINIMIZE])
     lmp_instance = lammps_run(
         structure=structure,
@@ -124,6 +162,19 @@ def calc_static_with_lammpslib(
     output_keys=OutputStatic.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run a static calculation using the LAMMPS library interface.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        output_keys: Which output quantities to return. Defaults to all ``OutputStatic`` keys.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        dict: Requested output quantities keyed by name.
+    """
     template_str = "\n".join([LAMMPS_THERMO_STYLE, LAMMPS_THERMO, LAMMPS_RUN])
     lmp_instance = lammps_run(
         structure=structure,
@@ -161,6 +212,29 @@ def calc_molecular_dynamics_nvt_with_lammpslib(
     output_keys=OutputMolecularDynamics.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run NVT (canonical ensemble) molecular dynamics using the LAMMPS library interface.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        Tstart (float): Starting temperature in K. Defaults to ``100.0``.
+        Tstop (float): Target temperature in K at the end of the run. Defaults to ``100.0``.
+        Tdamp (float): Nosé-Hoover thermostat damping parameter in ps. Defaults to ``0.1``.
+        run (int): Total number of MD timesteps. Defaults to ``100``.
+        thermo (int): Number of timesteps between output snapshots. Defaults to ``10``.
+        timestep (float): MD timestep in ps. Defaults to ``0.001``.
+        seed (int): Random seed for velocity initialisation. Defaults to ``4928459``.
+        dist (str): Velocity distribution type (``"gaussian"`` or ``"uniform"``). Defaults to ``"gaussian"``.
+        velocity_rescale_factor (float | None): Scaling factor for initial velocity rescaling.
+            No rescaling is applied when ``None``. Defaults to ``2.0``.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        output_keys: Which output quantities to return. Defaults to all ``OutputMolecularDynamics`` keys.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        dict: Output quantities as numpy arrays with one entry per snapshot, keyed by quantity name.
+    """
     if velocity_rescale_factor is not None:
         init_str = "\n".join(
             [
@@ -238,6 +312,34 @@ def calc_molecular_dynamics_npt_with_lammpslib(
     output_keys=OutputMolecularDynamics.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run NPT (isothermal-isobaric ensemble) molecular dynamics using the LAMMPS library interface.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        Tstart (float): Starting temperature in K. Defaults to ``100.0``.
+        Tstop (float): Target temperature in K at the end of the run. Defaults to ``100.0``.
+        Tdamp (float): Thermostat damping parameter in ps. Defaults to ``0.1``.
+        run (int): Total number of MD timesteps. Defaults to ``100``.
+        thermo (int): Number of timesteps between output snapshots. Defaults to ``100``.
+        timestep (float): MD timestep in ps. Defaults to ``0.001``.
+        Pstart (float): Starting pressure in bar. Defaults to ``0.0``.
+        Pstop (float): Target pressure in bar at the end of the run. Defaults to ``0.0``.
+        Pdamp (float): Barostat damping parameter in ps. Defaults to ``1.0``.
+        seed (int): Random seed for velocity initialisation. Defaults to ``4928459``.
+        dist (str): Velocity distribution type. Defaults to ``"gaussian"``.
+        couple_xyz (bool): Whether to couple all three box dimensions (isotropic pressure).
+            Defaults to ``False``.
+        velocity_rescale_factor (float | None): Scaling factor for initial velocity rescaling.
+            No rescaling is applied when ``None``. Defaults to ``2.0``.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        output_keys: Which output quantities to return. Defaults to all ``OutputMolecularDynamics`` keys.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        dict: Output quantities as numpy arrays with one entry per snapshot, keyed by quantity name.
+    """
     if couple_xyz:
         LAMMPS_ENSEMBLE_NPT_XYZ = LAMMPS_ENSEMBLE_NPT + " couple xyz"
     else:
@@ -322,6 +424,30 @@ def calc_molecular_dynamics_nph_with_lammpslib(
     output_keys=OutputMolecularDynamics.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run NPH (isoenthalpic-isobaric ensemble) molecular dynamics using the LAMMPS library interface.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        run (int): Total number of MD timesteps. Defaults to ``100``.
+        thermo (int): Number of timesteps between output snapshots. Defaults to ``100``.
+        timestep (float): MD timestep in ps. Defaults to ``0.001``.
+        Tstart (float): Initial temperature in K used for velocity initialisation. Defaults to ``100.0``.
+        Pstart (float): Starting pressure in bar. Defaults to ``0.0``.
+        Pstop (float): Target pressure in bar at the end of the run. Defaults to ``0.0``.
+        Pdamp (float): Barostat damping parameter in ps. Defaults to ``1.0``.
+        seed (int): Random seed for velocity initialisation. Defaults to ``4928459``.
+        dist (str): Velocity distribution type. Defaults to ``"gaussian"``.
+        velocity_rescale_factor (float | None): Scaling factor for initial velocity rescaling.
+            No rescaling is applied when ``None``. Defaults to ``2.0``.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        output_keys: Which output quantities to return. Defaults to all ``OutputMolecularDynamics`` keys.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        dict: Output quantities as numpy arrays with one entry per snapshot, keyed by quantity name.
+    """
     if velocity_rescale_factor is not None:
         init_str = "\n".join(
             [
@@ -395,6 +521,29 @@ def calc_molecular_dynamics_langevin_with_lammpslib(
     output_keys=OutputMolecularDynamics.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run Langevin (NVE + Langevin thermostat) molecular dynamics using the LAMMPS library interface.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        run (int): Total number of MD timesteps. Defaults to ``100``.
+        thermo (int): Number of timesteps between output snapshots. Defaults to ``100``.
+        timestep (float): MD timestep in ps. Defaults to ``0.001``.
+        Tstart (float): Starting temperature for the Langevin thermostat in K. Defaults to ``100.0``.
+        Tstop (float): Target temperature for the Langevin thermostat in K. Defaults to ``100``.
+        Tdamp (float): Langevin thermostat damping parameter in ps. Defaults to ``0.1``.
+        seed (int): Random seed for velocity initialisation and Langevin noise. Defaults to ``4928459``.
+        dist (str): Velocity distribution type. Defaults to ``"gaussian"``.
+        velocity_rescale_factor (float | None): Scaling factor for initial velocity rescaling.
+            No rescaling is applied when ``None``. Defaults to ``2.0``.
+        lmp: Existing LAMMPS library instance to reuse. A new instance is created if ``None``.
+        output_keys: Which output quantities to return. Defaults to all ``OutputMolecularDynamics`` keys.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_run``.
+
+    Returns:
+        dict: Output quantities as numpy arrays with one entry per snapshot, keyed by quantity name.
+    """
     if velocity_rescale_factor is not None:
         init_str = "\n".join(
             [
@@ -475,6 +624,36 @@ def calc_molecular_dynamics_thermal_expansion_with_lammpslib(
     output_keys: Iterable[str] = OutputThermalExpansion.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Compute thermal expansion via NPT MD across a temperature range using the LAMMPS library interface.
+
+    Runs ``lammps_thermal_expansion_loop`` over temperatures from ``Tstart`` to ``Tstop``
+    in steps of ``Tstep``.
+
+    Args:
+        structure (Atoms): The input structure.
+        potential_dataframe (pandas.DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        Tstart (float): Starting temperature in K. Defaults to ``15.0``.
+        Tstop (float): Ending temperature in K (inclusive). Defaults to ``1500.0``.
+        Tstep (int): Temperature increment in K. Defaults to ``5``.
+        Tdamp (float): Thermostat damping parameter in ps. Defaults to ``0.1``.
+        run (int): Number of MD timesteps per temperature point. Defaults to ``100``.
+        thermo (int): Thermo output frequency in timesteps. Defaults to ``100``.
+        timestep (float): MD timestep in ps. Defaults to ``0.001``.
+        Pstart (float): Starting pressure in bar. Defaults to ``0.0``.
+        Pstop (float): Ending pressure in bar. Defaults to ``0.0``.
+        Pdamp (float): Barostat damping parameter in ps. Defaults to ``1.0``.
+        seed (int): Random seed for velocity initialisation. Defaults to ``4928459``.
+        dist (str): Velocity distribution type. Defaults to ``"gaussian"``.
+        couple_xyz (bool): Whether to couple all three box dimensions (isotropic pressure).
+            Defaults to ``False``.
+        lmp (LammpsASELibrary | None): Existing LAMMPS library instance to reuse.
+        output_keys (Iterable[str]): Which output quantities to return.
+        **kwargs: Additional keyword arguments forwarded to ``lammps_thermal_expansion_loop``.
+
+    Returns:
+        dict: Thermal expansion output (temperatures and volumes) keyed by quantity name.
+    """
     init_str = "\n".join(
         [
             LAMMPS_THERMO_STYLE,
@@ -519,6 +698,26 @@ def evaluate_with_lammpslib_library_interface(
     lmp: LammpsASELibrary,
     lmp_optimizer_kwargs: dict | None = None,
 ) -> dict:
+    """
+    Evaluate a single structure for a list of tasks using an existing LAMMPS library instance.
+
+    Decorated with ``as_task_dict_evaluator`` to handle task dict conversion. Used internally
+    by ``evaluate_with_lammpslib`` which manages the LAMMPS instance lifecycle.
+
+    Args:
+        structure (Atoms): The input structure.
+        tasks (list[TaskName]): List of task names to evaluate.
+        potential_dataframe (DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        lmp (LammpsASELibrary): An active LAMMPS library instance.
+        lmp_optimizer_kwargs (dict | None): Extra keyword arguments forwarded to the
+            underlying calculation functions.
+
+    Returns:
+        dict: Results keyed by output quantity name.
+
+    Raises:
+        ValueError: If none of the requested tasks are implemented by this calculator.
+    """
     if lmp_optimizer_kwargs is None:
         lmp_optimizer_kwargs = {}
     results: dict[str, Any] = {}
@@ -575,6 +774,28 @@ def evaluate_with_lammpslib(
     disable_log_file: bool = True,
     lmp_optimizer_kwargs: dict | None = None,
 ) -> dict:
+    """
+    Evaluate a task dictionary using the LAMMPS library interface, managing the instance lifecycle.
+
+    Creates a ``LammpsASELibrary`` instance, delegates to
+    ``evaluate_with_lammpslib_library_interface``, then closes the instance.
+
+    Args:
+        task_dict (dict[str, dict[str, Atoms]]): Task dictionary mapping task names to structure dicts.
+        potential_dataframe (DataFrame): DataFrame with ``"Species"`` and ``"Config"`` columns.
+        working_directory (str | None): Working directory for LAMMPS. Defaults to ``None``.
+        cores (int): Number of MPI cores to use. Defaults to ``1``.
+        comm: MPI communicator object. Defaults to ``None``.
+        logger: Logger object. Defaults to ``None``.
+        log_file (str | None): Path to the LAMMPS log file. Defaults to ``None``.
+        library: Pre-loaded LAMMPS shared library object. Defaults to ``None``.
+        disable_log_file (bool): Whether to suppress the LAMMPS log file. Defaults to ``True``.
+        lmp_optimizer_kwargs (dict | None): Extra keyword arguments forwarded to the
+            underlying calculation functions.
+
+    Returns:
+        dict: Results keyed by output quantity name.
+    """
     if lmp_optimizer_kwargs is None:
         lmp_optimizer_kwargs = {}
     lmp = LammpsASELibrary(

--- a/src/atomistics/calculators/lammps/melting.py
+++ b/src/atomistics/calculators/lammps/melting.py
@@ -69,12 +69,22 @@ def _analyse_structure(structure: Atoms, mode: str = "total", diamond: bool = Fa
 
 def _analyse_minimized_structure(structure: Atoms):
     """
+    Determine the dominant structural motif of a minimised structure.
+
+    Runs the appropriate structure analysis (CNA or diamond detector) and returns
+    the dominant phase key, total atom count, and a threshold fraction used to
+    distinguish solid from liquid during bisection.
 
     Args:
-        ham (GenericJob):
+        structure (Atoms): The energy-minimised structure to analyse.
 
     Returns:
-
+        tuple: A 5-tuple containing:
+            - structure (Atoms): The input structure (passed through).
+            - key_max (str): The OVITO key of the dominant structural motif.
+            - number_of_atoms (int): Total number of atoms.
+            - distribution_initial_half (float): Half the initial fraction of atoms in the dominant phase.
+            - final_structure_dict (dict): Full analysis result dictionary.
     """
     diamond_flag = _check_diamond(structure=structure)
     final_structure_dict = _analyse_structure(
@@ -154,20 +164,37 @@ def _next_step_funct(
     seed: int,
 ):
     """
+    Perform one bisection step in the melting temperature search.
+
+    Analyses the structural order of the left and right bracket structures and
+    adjusts the temperature bracket accordingly:
+
+    - Both solid → shift the bracket upward.
+    - Left solid, right liquid → bisect downward.
+    - Both liquid → shift the bracket downward.
 
     Args:
-        number_of_atoms:
-        key_max:
-        structure_left:
-        structure_right:
-        temperature_left:
-        temperature_right:
-        distribution_initial_half:
-        structure_after_minimization:
-        run_time_steps:
+        number_of_atoms (int): Total number of atoms in the simulation cell.
+        key_max (str): OVITO key of the dominant structural motif in the solid phase.
+        structure_left (Atoms): Structure equilibrated at ``temperature_left``.
+        structure_right (Atoms): Structure equilibrated at ``temperature_right``.
+        potential (pd.DataFrame): Interatomic potential DataFrame.
+        temperature_left (float): Lower bound of the current temperature bracket in K.
+        temperature_right (float): Upper bound of the current temperature bracket in K.
+        distribution_initial_half (float): Half of the initial solid-phase atom fraction
+            (threshold for solid/liquid classification).
+        structure_after_minimization (Atoms): The energy-minimised reference structure used
+            to seed new MD runs.
+        run_time_steps (int): Number of NPT MD timesteps per bracket point.
+        diamond_flag (bool): Whether to use the diamond structure detector instead of CNA.
+        seed (int): Random seed for MD velocity initialisation.
 
     Returns:
+        tuple[Atoms, Atoms, float, float]: Updated
+            ``(structure_left, structure_right, temperature_left, temperature_right)``.
 
+    Raises:
+        ValueError: If none of the three expected cases is satisfied (should never happen).
     """
     structure_left_dict = _analyse_structure(
         structure=structure_left,
@@ -231,6 +258,20 @@ def _next_step_funct(
 def _generate_structure_with_fixed_number_of_atoms(
     structure: Atoms, number_of_atoms: int
 ) -> Atoms:
+    """
+    Repeat a unit cell to reach approximately ``number_of_atoms`` atoms.
+
+    Estimates the cubic repetition factor from the ratio of target to current atom count,
+    tries floor/round/ceil candidates, and returns the repeat that minimises the
+    difference from ``number_of_atoms``. The minimum repetition is 5×5×5.
+
+    Args:
+        structure (Atoms): The primitive or conventional unit cell to tile.
+        number_of_atoms (int): Approximate target number of atoms.
+
+    Returns:
+        Atoms: The supercell with the atom count closest to ``number_of_atoms``.
+    """
     r_est = (number_of_atoms / len(structure)) ** (1 / 3)
     candidates = np.array(
         [
@@ -257,7 +298,37 @@ def estimate_melting_temperature_using_bisection_CNA(
     run: int = 10000,
     optimization_maxiter: int = 100000,
     seed: Optional[int] = None,
-):
+) -> int:
+    """
+    Estimate the melting temperature using bisection and common neighbour analysis (CNA).
+
+    The algorithm:
+
+    1. Tiles the unit cell to approximately ``target_number_of_atoms`` atoms.
+    2. Energy-minimises the supercell.
+    3. Identifies the dominant structural motif and sets a solid/liquid threshold.
+    4. Iteratively bisects the temperature bracket (via NPT MD + CNA) until the
+       bracket width falls below 10 K.
+
+    Args:
+        structure (Atoms): The input unit cell.
+        potential_dataframe (pd.DataFrame): Interatomic potential DataFrame with
+            ``"Species"`` and ``"Config"`` columns.
+        target_number_of_atoms (int): Approximate number of atoms for the supercell.
+            Defaults to ``4000``.
+        temperature_left (float): Lower bound of the initial temperature bracket in K.
+            Defaults to ``0``.
+        temperature_right (float): Upper bound of the initial temperature bracket in K.
+            Defaults to ``1000``.
+        run (int): Number of NPT MD timesteps per bracket evaluation. Defaults to ``10000``.
+        optimization_maxiter (int): Maximum iterations for the initial energy minimisation.
+            Defaults to ``100000``.
+        seed (int | None): Random seed for MD velocity initialisation. A random seed is
+            chosen if ``None``.
+
+    Returns:
+        int: Estimated melting temperature in K (rounded to the nearest integer).
+    """
     if seed is None:
         seed = random.randint(0, 99999)
     seed = int(seed)

--- a/src/atomistics/calculators/lammps/shared.py
+++ b/src/atomistics/calculators/lammps/shared.py
@@ -5,6 +5,28 @@ from typing import Optional
 def get_box_relax_command(
     pressure: float | Iterable[float | None], vmax: Optional[float]
 ) -> str:
+    """
+    Build a LAMMPS ``fix box/relax`` command string for the given pressure specification.
+
+    When ``pressure`` is a scalar the command uses isotropic relaxation (``iso``).
+    When ``pressure`` is an iterable of length 3, the x/y/z components are set
+    individually; components that are ``None`` are omitted.  An iterable of length 6
+    additionally sets the xy/xz/yz off-diagonal components.
+
+    Args:
+        pressure (float | Iterable[float | None]): Target pressure in bar.
+            A scalar applies isotropic pressure; an iterable of 3 or 6 elements
+            applies anisotropic pressure component-wise (``None`` entries are skipped).
+        vmax (float | None): Maximum fractional volume change per timestep (LAMMPS
+            ``vmax`` keyword).  No ``vmax`` clause is added when ``None``.
+
+    Returns:
+        str: A complete LAMMPS ``fix`` command string.
+
+    Raises:
+        ValueError: If ``pressure`` is an iterable whose length is not 3 or 6.
+        TypeError: If ``vmax`` is not a ``float``.
+    """
     if not isinstance(pressure, Iterable):
         box_relax = f"fix ensemble all box/relax iso {pressure}"
     else:

--- a/src/atomistics/calculators/sphinxdft.py
+++ b/src/atomistics/calculators/sphinxdft.py
@@ -29,6 +29,21 @@ def _generate_input(
     kpoint_coords: Optional[list[float]] = None,
     kpoint_folding: Optional[list[int]] = None,
 ):
+    """
+    Build a SphinxDFT input object for a PAW calculation.
+
+    Args:
+        structure (Atoms): The input ASE structure.
+        maxSteps (int): Maximum number of SCF steps. Defaults to ``100``.
+        energy_cutoff_in_eV (float): Plane-wave energy cutoff in eV. Defaults to ``500.0``.
+        kpoint_coords (list[float] | None): Fractional coordinates of the single k-point shift.
+            Defaults to ``[0.5, 0.5, 0.5]``.
+        kpoint_folding (list[int] | None): Monkhorst-Pack k-point folding.
+            Defaults to ``[3, 3, 3]``.
+
+    Returns:
+        sphinx: A SphinxDFT input group object ready to be serialised with ``to_sphinx``.
+    """
     if kpoint_coords is None:
         kpoint_coords = [0.5, 0.5, 0.5]
     if kpoint_folding is None:
@@ -60,11 +75,19 @@ def _generate_input(
 
 
 class OutputParser:
+    """Parse SphinxDFT output files from a completed calculation.
+
+    Args:
+        working_directory (str): Path to the directory containing SphinxDFT output files.
+        structure (Atoms): The input ASE structure used for the calculation.
+    """
+
     def __init__(self, working_directory: str, structure: Atoms):
         self._working_directory = working_directory
         self._structure = structure
 
-    def get_energy(self):
+    def get_energy(self) -> float:
+        """Return the last converged SCF total energy in eV."""
         return (
             collect_energy_dat(os.path.join(self._working_directory, "energy.dat"))[
                 "scf_energy_int"
@@ -72,7 +95,8 @@ class OutputParser:
             * HARTREE_TO_EV
         )
 
-    def get_forces(self):
+    def get_forces(self) -> list:
+        """Return the atomic forces from the last relaxation step in eV/Å."""
         return (
             collect_eval_forces(os.path.join(self._working_directory, "relaxHist.sx"))[
                 "forces"
@@ -80,10 +104,12 @@ class OutputParser:
             * HARTREE_OVER_BOHR_TO_EV_OVER_ANGSTROM
         )
 
-    def get_volume(self):
+    def get_volume(self) -> float:
+        """Return the cell volume of the input structure in Å³."""
         return self._structure.get_volume()
 
     def get_stress(self):
+        """Not implemented for SphinxDFT."""
         raise NotImplementedError()
 
 
@@ -99,6 +125,26 @@ def optimize_positions_with_sphinxdft(
     kpoint_coords: Optional[list[float]] = None,
     kpoint_folding: Optional[list[int]] = None,
 ) -> Atoms:
+    """
+    Relax atomic positions with SphinxDFT (cell fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for SphinxDFT input/output files.
+        executable_function (Callable[[str], object]): Callable that executes SphinxDFT in the given directory.
+        max_electronic_steps (int): Maximum number of SCF iterations per ionic step. Defaults to ``100``.
+        energy_cutoff_in_eV (float): Plane-wave energy cutoff in eV. Defaults to ``500.0``.
+        mode (str): Ionic minimisation algorithm (e.g. ``"linQN"``). Defaults to ``"linQN"``.
+        dEnergy (float): Energy convergence threshold in Hartree for ionic relaxation. Defaults to ``1e-6``.
+        max_ionic_steps (int): Maximum number of ionic steps. Defaults to ``50``.
+        kpoint_coords (list[float] | None): Fractional k-point shift coordinates.
+            Defaults to ``[0.5, 0.5, 0.5]``.
+        kpoint_folding (list[int] | None): Monkhorst-Pack k-point folding.
+            Defaults to ``[3, 3, 3]``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed atomic positions.
+    """
     if kpoint_coords is None:
         kpoint_coords = [0.5, 0.5, 0.5]
     if kpoint_folding is None:
@@ -139,6 +185,24 @@ def calc_static_with_sphinxdft(
     kpoint_folding: Optional[list[int]] = None,
     output_keys=OutputStatic.keys(),
 ) -> dict:
+    """
+    Run a static SphinxDFT calculation and return the requested output quantities.
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for SphinxDFT input/output files.
+        executable_function (Callable[[str], object]): Callable that executes SphinxDFT in the given directory.
+        max_electronic_steps (int): Maximum number of SCF iterations. Defaults to ``100``.
+        energy_cutoff_in_eV (float): Plane-wave energy cutoff in eV. Defaults to ``500.0``.
+        kpoint_coords (list[float] | None): Fractional k-point shift coordinates.
+            Defaults to ``[0.5, 0.5, 0.5]``.
+        kpoint_folding (list[int] | None): Monkhorst-Pack k-point folding.
+            Defaults to ``[3, 3, 3]``.
+        output_keys: Which output quantities to return. Defaults to all ``OutputStatic`` keys.
+
+    Returns:
+        dict: Requested output quantities keyed by name.
+    """
     if kpoint_coords is None:
         kpoint_coords = [0.5, 0.5, 0.5]
     if kpoint_folding is None:
@@ -175,6 +239,32 @@ def evaluate_with_sphinx(
     kpoint_folding: Optional[list[int]] = None,
     sphinx_optimizer_kwargs: Optional[dict] = None,
 ) -> dict:
+    """
+    Evaluate a task dictionary using SphinxDFT and return results for all requested tasks.
+
+    Dispatches to ``optimize_positions_with_sphinxdft`` or ``calc_static_with_sphinxdft``
+    based on the requested tasks. Decorated with ``as_task_dict_evaluator``.
+
+    Args:
+        structure (Atoms): The input structure.
+        tasks (list): List of task name strings (e.g. ``["calc_energy"]``).
+        working_directory (str): Directory used for SphinxDFT input/output files.
+        executable_function (Callable[[str], object]): Callable that executes SphinxDFT in the given directory.
+        max_electronic_steps (int): Maximum number of SCF iterations. Defaults to ``100``.
+        energy_cutoff_in_eV (float): Plane-wave energy cutoff in eV. Defaults to ``500``.
+        kpoint_coords (list[float] | None): Fractional k-point shift coordinates.
+            Defaults to ``[0.5, 0.5, 0.5]``.
+        kpoint_folding (list[int] | None): Monkhorst-Pack k-point folding.
+            Defaults to ``[3, 3, 3]``.
+        sphinx_optimizer_kwargs (dict | None): Extra keyword arguments forwarded to
+            ``optimize_positions_with_sphinxdft``.
+
+    Returns:
+        dict: Results keyed by output quantity name.
+
+    Raises:
+        ValueError: If none of the requested tasks are implemented by this calculator.
+    """
     if kpoint_coords is None:
         kpoint_coords = [0.5, 0.5, 0.5]
     if kpoint_folding is None:

--- a/src/atomistics/calculators/vasp.py
+++ b/src/atomistics/calculators/vasp.py
@@ -12,25 +12,44 @@ from atomistics.shared.output import OutputStatic
 
 
 class OutputParser:
+    """Parse VASP output files from a completed calculation.
+
+    Args:
+        working_directory (str): Path to the directory containing VASP output files.
+        structure (Atoms): The input ASE structure used for the calculation.
+    """
+
     def __init__(self, working_directory: str, structure: Atoms):
         self._output_dict = parse_vasp_output(
             working_directory=working_directory, structure=structure
         )
 
-    def get_energy(self):
+    def get_energy(self) -> float:
+        """Return the total energy from the last ionic step in eV."""
         return self._output_dict["generic"]["energy_tot"][-1]
 
-    def get_forces(self):
+    def get_forces(self) -> list:
+        """Return the atomic forces from the last ionic step in eV/Å."""
         return self._output_dict["generic"]["forces"][-1]
 
-    def get_volume(self):
+    def get_volume(self) -> float:
+        """Return the cell volume from the last ionic step in Å³."""
         return self._output_dict["generic"]["volume"][-1]
 
-    def get_stress(self):
+    def get_stress(self) -> list:
+        """Return the stress tensor from the last ionic step in kBar."""
         return self._output_dict["generic"]["stresses"][-1]
 
 
 def write_input(working_directory: str, atoms: Atoms, **kwargs) -> None:
+    """
+    Write VASP input files (INCAR, KPOINTS, POSCAR, POTCAR) to a directory.
+
+    Args:
+        working_directory (str): Directory in which to write the input files (created if absent).
+        atoms (Atoms): The ASE structure to use as the POSCAR.
+        **kwargs: Additional VASP settings forwarded to ``GenerateVaspInput.set``.
+    """
     vip = GenerateVaspInput()
     vip.set(**kwargs)
     vip.initialize(atoms=atoms)
@@ -51,6 +70,25 @@ def calc_static_with_vasp(
     output_keys: list[str] | tuple[str, ...] = OutputStatic.keys(),
     **kwargs,
 ) -> dict:
+    """
+    Run a static VASP calculation and return the requested output quantities.
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for VASP input/output files.
+        executable_function (Callable[[str], object]): Callable that executes VASP in the given directory.
+        prec (str): VASP precision tag (PREC). Defaults to ``"Accurate"``.
+        algo (str): Electronic minimisation algorithm (ALGO). Defaults to ``"Fast"``.
+        lreal (bool): Whether to use real-space projection (LREAL). Defaults to ``False``.
+        lwave (bool): Whether to write the wave function file (LWAVE). Defaults to ``False``.
+        lorbit (int): Controls orbital-decomposed DOS/PROCAR output (LORBIT). Defaults to ``0``.
+        kpts (list[int] | None): Monkhorst-Pack k-point mesh. Defaults to ``[4, 4, 4]``.
+        output_keys (list[str] | tuple[str, ...]): Which output quantities to return.
+        **kwargs: Additional VASP settings forwarded to ``write_input``.
+
+    Returns:
+        dict: Requested output quantities keyed by name.
+    """
     if kpts is None:
         kpts = [4, 4, 4]
     write_input(
@@ -90,6 +128,27 @@ def optimize_positions_with_vasp(
     kpts: Optional[list[int]] = None,
     **kwargs,
 ) -> Atoms:
+    """
+    Relax atomic positions with VASP (cell shape and volume fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for VASP input/output files.
+        executable_function (Callable[[str], object]): Callable that executes VASP in the given directory.
+        prec (str): VASP precision tag (PREC). Defaults to ``"Accurate"``.
+        algo (str): Electronic minimisation algorithm (ALGO). Defaults to ``"Fast"``.
+        lreal (bool): Whether to use real-space projection (LREAL). Defaults to ``False``.
+        lwave (bool): Whether to write the wave function file (LWAVE). Defaults to ``False``.
+        lorbit (int): Controls orbital-decomposed DOS/PROCAR output (LORBIT). Defaults to ``0``.
+        isif (int): VASP ISIF tag controlling which degrees of freedom are relaxed. Defaults to ``2``.
+        ibrion (int): VASP IBRION tag selecting the ionic relaxation algorithm. Defaults to ``2``.
+        nsw (int): Maximum number of ionic steps (NSW). Defaults to ``100``.
+        kpts (list[int] | None): Monkhorst-Pack k-point mesh. Defaults to ``[4, 4, 4]``.
+        **kwargs: Additional VASP settings forwarded to ``write_input``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed atomic positions.
+    """
     if kpts is None:
         kpts = [4, 4, 4]
     write_input(
@@ -130,6 +189,27 @@ def optimize_positions_and_volume_with_vasp(
     kpts: Optional[list[int]] = None,
     **kwargs,
 ) -> Atoms:
+    """
+    Relax atomic positions and cell volume with VASP (cell shape fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for VASP input/output files.
+        executable_function (Callable[[str], object]): Callable that executes VASP in the given directory.
+        prec (str): VASP precision tag (PREC). Defaults to ``"Accurate"``.
+        algo (str): Electronic minimisation algorithm (ALGO). Defaults to ``"Fast"``.
+        lreal (bool): Whether to use real-space projection (LREAL). Defaults to ``False``.
+        lwave (bool): Whether to write the wave function file (LWAVE). Defaults to ``False``.
+        lorbit (int): Controls orbital-decomposed DOS/PROCAR output (LORBIT). Defaults to ``0``.
+        isif (int): VASP ISIF tag (3 = relax positions and volume). Defaults to ``3``.
+        ibrion (int): VASP IBRION tag selecting the ionic relaxation algorithm. Defaults to ``2``.
+        nsw (int): Maximum number of ionic steps (NSW). Defaults to ``100``.
+        kpts (list[int] | None): Monkhorst-Pack k-point mesh. Defaults to ``[4, 4, 4]``.
+        **kwargs: Additional VASP settings forwarded to ``write_input``.
+
+    Returns:
+        Atoms: A copy of the input structure with relaxed positions and scaled cell.
+    """
     if kpts is None:
         kpts = [4, 4, 4]
     write_input(
@@ -171,6 +251,27 @@ def optimize_volume_with_vasp(
     kpts: Optional[list[int]] = None,
     **kwargs,
 ) -> Atoms:
+    """
+    Relax cell volume with VASP (positions and cell shape fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for VASP input/output files.
+        executable_function (Callable[[str], object]): Callable that executes VASP in the given directory.
+        prec (str): VASP precision tag (PREC). Defaults to ``"Accurate"``.
+        algo (str): Electronic minimisation algorithm (ALGO). Defaults to ``"Fast"``.
+        lreal (bool): Whether to use real-space projection (LREAL). Defaults to ``False``.
+        lwave (bool): Whether to write the wave function file (LWAVE). Defaults to ``False``.
+        lorbit (int): Controls orbital-decomposed DOS/PROCAR output (LORBIT). Defaults to ``0``.
+        isif (int): VASP ISIF tag (7 = volume only). Defaults to ``7``.
+        ibrion (int): VASP IBRION tag selecting the ionic relaxation algorithm. Defaults to ``2``.
+        nsw (int): Maximum number of ionic steps (NSW). Defaults to ``100``.
+        kpts (list[int] | None): Monkhorst-Pack k-point mesh. Defaults to ``[4, 4, 4]``.
+        **kwargs: Additional VASP settings forwarded to ``write_input``.
+
+    Returns:
+        Atoms: A copy of the input structure with the cell scaled to the optimised volume.
+    """
     if kpts is None:
         kpts = [4, 4, 4]
     write_input(
@@ -211,6 +312,27 @@ def optimize_cell_with_vasp(
     kpts: Optional[list[int]] = None,
     **kwargs,
 ) -> Atoms:
+    """
+    Relax cell shape and volume with VASP (atomic positions fixed).
+
+    Args:
+        structure (Atoms): The input structure.
+        working_directory (str): Directory used for VASP input/output files.
+        executable_function (Callable[[str], object]): Callable that executes VASP in the given directory.
+        prec (str): VASP precision tag (PREC). Defaults to ``"Accurate"``.
+        algo (str): Electronic minimisation algorithm (ALGO). Defaults to ``"Fast"``.
+        lreal (bool): Whether to use real-space projection (LREAL). Defaults to ``False``.
+        lwave (bool): Whether to write the wave function file (LWAVE). Defaults to ``False``.
+        lorbit (int): Controls orbital-decomposed DOS/PROCAR output (LORBIT). Defaults to ``0``.
+        isif (int): VASP ISIF tag (5 = cell shape and volume, positions fixed). Defaults to ``5``.
+        ibrion (int): VASP IBRION tag selecting the ionic relaxation algorithm. Defaults to ``2``.
+        nsw (int): Maximum number of ionic steps (NSW). Defaults to ``100``.
+        kpts (list[int] | None): Monkhorst-Pack k-point mesh. Defaults to ``[4, 4, 4]``.
+        **kwargs: Additional VASP settings forwarded to ``write_input``.
+
+    Returns:
+        Atoms: A copy of the input structure with the relaxed cell.
+    """
     if kpts is None:
         kpts = [4, 4, 4]
     write_input(
@@ -250,6 +372,32 @@ def evaluate_with_vasp(
     kpts: Optional[list[int]] = None,
     **kwargs,
 ) -> dict:
+    """
+    Evaluate a task dictionary using VASP and return results for all requested tasks.
+
+    Dispatches to the appropriate VASP calculation function based on the tasks requested.
+    Decorated with ``as_task_dict_evaluator`` so it accepts a task dict and returns a
+    results dict rather than operating on a single structure.
+
+    Args:
+        structure (Atoms): The input structure.
+        tasks (list): List of task name strings (e.g. ``["calc_energy", "calc_forces"]``).
+        working_directory (str): Directory used for VASP input/output files.
+        executable_function (Callable[[str], object]): Callable that executes VASP in the given directory.
+        prec (str): VASP precision tag (PREC). Defaults to ``"Accurate"``.
+        algo (str): Electronic minimisation algorithm (ALGO). Defaults to ``"Fast"``.
+        lreal (bool): Whether to use real-space projection (LREAL). Defaults to ``False``.
+        lwave (bool): Whether to write the wave function file (LWAVE). Defaults to ``False``.
+        lorbit (int): Controls orbital-decomposed DOS/PROCAR output (LORBIT). Defaults to ``0``.
+        kpts (list[int] | None): Monkhorst-Pack k-point mesh. Defaults to ``[4, 4, 4]``.
+        **kwargs: Additional VASP settings forwarded to the underlying calculation functions.
+
+    Returns:
+        dict: Results keyed by output quantity name.
+
+    Raises:
+        ValueError: If none of the requested tasks are implemented by this calculator.
+    """
     if kpts is None:
         kpts = [4, 4, 4]
     results = {}

--- a/src/atomistics/calculators/wrapper.py
+++ b/src/atomistics/calculators/wrapper.py
@@ -63,6 +63,22 @@ def as_task_dict_evaluator(
         *calculate_args: Any,
         **calculate_kwargs: Any,
     ) -> ResultsDict:
+        """
+        Evaluate all structures in ``task_dict`` and aggregate results.
+
+        Converts the legacy task-dict format to the new per-structure format,
+        calls the wrapped ``calculate`` function for each structure, and maps
+        the per-structure outputs back to the nested results dictionary.
+
+        Args:
+            task_dict (dict[TaskName, dict[str, Atoms]]): Mapping from task names to
+                structure label → structure dicts.
+            *calculate_args: Positional arguments forwarded to ``calculate``.
+            **calculate_kwargs: Keyword arguments forwarded to ``calculate``.
+
+        Returns:
+            ResultsDict: Nested mapping ``{output_label: {structure_label: result}}``.
+        """
         converted_task_dict = _convert_task_dict(
             cast(dict[TaskName, dict[str, Atoms] | Atoms], task_dict)
         )

--- a/src/atomistics/shared/import_warning.py
+++ b/src/atomistics/shared/import_warning.py
@@ -2,6 +2,13 @@ import warnings
 
 
 def raise_warning(module_list, import_error):
+    """
+    Issue a UserWarning when one or more optional module functions are unavailable.
+
+    Args:
+        module_list (list[str]): Names of the functions that could not be imported.
+        import_error (ImportError): The import error that caused the unavailability.
+    """
     if len(module_list) == 1:
         warnings.warn(
             message=module_list[0]

--- a/src/atomistics/shared/output.py
+++ b/src/atomistics/shared/output.py
@@ -35,6 +35,15 @@ class Output:
 
 @dataclasses.dataclass
 class OutputStatic(Output):
+    """Output data for a static (single-point) calculation.
+
+    Attributes:
+        forces (OutputCallable): Callable returning atomic forces in eV/Å.
+        energy (OutputCallable): Callable returning the total energy in eV.
+        stress (OutputCallable): Callable returning the stress tensor in eV/Å³.
+        volume (OutputCallable): Callable returning the cell volume in Å³.
+    """
+
     forces: OutputCallable
     energy: OutputCallable
     stress: OutputCallable
@@ -43,6 +52,20 @@ class OutputStatic(Output):
 
 @dataclasses.dataclass
 class OutputMolecularDynamics(Output):
+    """Output data for a molecular dynamics calculation.
+
+    Attributes:
+        positions (OutputCallable): Callable returning atomic positions in Å.
+        cell (OutputCallable): Callable returning the simulation cell matrix in Å.
+        forces (OutputCallable): Callable returning atomic forces in eV/Å.
+        temperature (OutputCallable): Callable returning the instantaneous temperature in K.
+        energy_pot (OutputCallable): Callable returning the potential energy in eV.
+        energy_tot (OutputCallable): Callable returning the total energy in eV.
+        pressure (OutputCallable): Callable returning the pressure tensor in GPa.
+        velocities (OutputCallable): Callable returning atomic velocities in Å/ps.
+        volume (OutputCallable): Callable returning the cell volume in Å³.
+    """
+
     positions: OutputCallable
     cell: OutputCallable
     forces: OutputCallable
@@ -56,12 +79,29 @@ class OutputMolecularDynamics(Output):
 
 @dataclasses.dataclass
 class OutputThermalExpansion(Output):
+    """Output data for a thermal expansion calculation.
+
+    Attributes:
+        temperatures (OutputCallable): Callable returning the list of temperatures in K.
+        volumes (OutputCallable): Callable returning the equilibrium volumes at each temperature in Å³.
+    """
+
     temperatures: OutputCallable
     volumes: OutputCallable
 
 
 @dataclasses.dataclass
 class OutputThermodynamic(OutputThermalExpansion):
+    """Output data for thermodynamic properties derived from thermal expansion.
+
+    Extends OutputThermalExpansion with thermodynamic quantities.
+
+    Attributes:
+        free_energy (OutputCallable): Callable returning the Helmholtz free energy in eV.
+        entropy (OutputCallable): Callable returning the entropy in eV/K.
+        heat_capacity (OutputCallable): Callable returning the heat capacity in eV/K.
+    """
+
     free_energy: OutputCallable
     entropy: OutputCallable
     heat_capacity: OutputCallable
@@ -69,21 +109,45 @@ class OutputThermodynamic(OutputThermalExpansion):
 
 @dataclasses.dataclass
 class EquilibriumEnergy(Output):
+    """Output data for the equilibrium energy from an equation-of-state fit.
+
+    Attributes:
+        energy_eq (OutputCallable): Callable returning the equilibrium energy in eV.
+    """
+
     energy_eq: OutputCallable
 
 
 @dataclasses.dataclass
 class EquilibriumVolume(Output):
+    """Output data for the equilibrium volume from an equation-of-state fit.
+
+    Attributes:
+        volume_eq (OutputCallable): Callable returning the equilibrium volume in Å³.
+    """
+
     volume_eq: OutputCallable
 
 
 @dataclasses.dataclass
 class EquilibriumBulkModul(Output):
+    """Output data for the equilibrium bulk modulus from an equation-of-state fit.
+
+    Attributes:
+        bulkmodul_eq (OutputCallable): Callable returning the equilibrium bulk modulus in GPa.
+    """
+
     bulkmodul_eq: OutputCallable
 
 
 @dataclasses.dataclass
 class EquilibriumBulkModulDerivative(Output):
+    """Output data for the pressure derivative of the bulk modulus from an EOS fit.
+
+    Attributes:
+        b_prime_eq (OutputCallable): Callable returning the equilibrium bulk modulus pressure derivative (dimensionless).
+    """
+
     b_prime_eq: OutputCallable
 
 
@@ -94,6 +158,16 @@ class OutputEnergyVolumeCurve(
     EquilibriumBulkModul,
     EquilibriumBulkModulDerivative,
 ):
+    """Output data for an energy-volume curve workflow.
+
+    Combines equilibrium properties with the raw EOS fit data.
+
+    Attributes:
+        fit_dict (OutputCallable): Callable returning the full EOS fit parameter dictionary.
+        energy (OutputCallable): Callable returning the energies at each sampled volume in eV.
+        volume (OutputCallable): Callable returning the sampled volumes in Å³.
+    """
+
     fit_dict: OutputCallable
     energy: OutputCallable
     volume: OutputCallable
@@ -101,6 +175,29 @@ class OutputEnergyVolumeCurve(
 
 @dataclasses.dataclass
 class OutputElastic(Output):
+    """Output data for an elastic constants calculation.
+
+    All moduli are in GPa; Poisson ratios and AVR are dimensionless.
+
+    Attributes:
+        elastic_matrix (OutputCallable): Callable returning the 6×6 Voigt elastic matrix in GPa.
+        elastic_matrix_inverse (OutputCallable): Callable returning the compliance matrix (inverse of elastic_matrix).
+        bulkmodul_voigt (OutputCallable): Callable returning the Voigt-averaged bulk modulus in GPa.
+        bulkmodul_reuss (OutputCallable): Callable returning the Reuss-averaged bulk modulus in GPa.
+        bulkmodul_hill (OutputCallable): Callable returning the Hill-averaged bulk modulus in GPa.
+        shearmodul_voigt (OutputCallable): Callable returning the Voigt-averaged shear modulus in GPa.
+        shearmodul_reuss (OutputCallable): Callable returning the Reuss-averaged shear modulus in GPa.
+        shearmodul_hill (OutputCallable): Callable returning the Hill-averaged shear modulus in GPa.
+        youngsmodul_voigt (OutputCallable): Callable returning the Voigt-averaged Young's modulus in GPa.
+        youngsmodul_reuss (OutputCallable): Callable returning the Reuss-averaged Young's modulus in GPa.
+        youngsmodul_hill (OutputCallable): Callable returning the Hill-averaged Young's modulus in GPa.
+        poissonsratio_voigt (OutputCallable): Callable returning the Voigt-averaged Poisson's ratio.
+        poissonsratio_reuss (OutputCallable): Callable returning the Reuss-averaged Poisson's ratio.
+        poissonsratio_hill (OutputCallable): Callable returning the Hill-averaged Poisson's ratio.
+        AVR (OutputCallable): Callable returning the Voigt-Reuss-Hill anisotropy ratio.
+        elastic_matrix_eigval (OutputCallable): Callable returning the eigenvalues of the elastic matrix.
+    """
+
     elastic_matrix: OutputCallable
     elastic_matrix_inverse: OutputCallable
     bulkmodul_voigt: OutputCallable
@@ -121,6 +218,16 @@ class OutputElastic(Output):
 
 @dataclasses.dataclass
 class OutputPhonons(Output):
+    """Output data for a phonon calculation.
+
+    Attributes:
+        mesh_dict (OutputCallable): Callable returning the phonon mesh sampling results.
+        band_structure_dict (OutputCallable): Callable returning the phonon band structure along high-symmetry paths.
+        total_dos_dict (OutputCallable): Callable returning the total phonon density of states.
+        dynamical_matrix (OutputCallable): Callable returning the dynamical matrix.
+        force_constants (OutputCallable): Callable returning the interatomic force constants matrix.
+    """
+
     mesh_dict: OutputCallable
     band_structure_dict: OutputCallable
     total_dos_dict: OutputCallable

--- a/src/atomistics/workflows/elastic/helper.py
+++ b/src/atomistics/workflows/elastic/helper.py
@@ -19,6 +19,26 @@ def _get_eta_matrix(
     epss: np.ndarray,
     sqrt_eta: bool = True,
 ) -> dict[str, np.ndarray]:
+    """
+    Compute the Lagrangian strain matrices for all strain–amplitude combinations.
+
+    For each Lagrangian strain pattern and each non-zero strain amplitude, builds the
+    symmetric 3×3 eta matrix from the Voigt strain vector and optionally applies the
+    square-root mapping so that the resulting deformation gradient is symmetric.
+
+    Args:
+        Lag_strain_list (list[str]): List of Lagrangian strain pattern keys (looked up in ``Ls_Dic``).
+        epss (np.ndarray): Array of strain amplitudes (zero values are skipped).
+        sqrt_eta (bool): Whether to iteratively solve for the symmetric square root of the
+            strain matrix. Required for accurate large-strain calculations. Defaults to ``True``.
+
+    Returns:
+        dict[str, np.ndarray]: Mapping from subjob name to the 3×3 deformation matrix for
+            each (strain pattern, amplitude) pair.
+
+    Raises:
+        Exception: If the norm of the strain matrix exceeds 0.7 (deformation too large).
+    """
     eps_dict = {}
     for lag_strain in Lag_strain_list:
         Ls_list = Ls_Dic[lag_strain]

--- a/src/atomistics/workflows/interface.py
+++ b/src/atomistics/workflows/interface.py
@@ -9,6 +9,7 @@ class Workflow(ABC):
     a task dictionary of structures to evaluate, and ``analyse_structures``
     consumes the calculator output to return the final workflow result.
     """
+
     @abstractmethod
     def generate_structures(self) -> dict[str, Any]:
         """

--- a/src/atomistics/workflows/interface.py
+++ b/src/atomistics/workflows/interface.py
@@ -3,6 +3,12 @@ from typing import Any
 
 
 class Workflow(ABC):
+    """Abstract base class for atomistics simulation workflows.
+
+    Subclasses implement a two-phase protocol: ``generate_structures`` produces
+    a task dictionary of structures to evaluate, and ``analyse_structures``
+    consumes the calculator output to return the final workflow result.
+    """
     @abstractmethod
     def generate_structures(self) -> dict[str, Any]:
         """


### PR DESCRIPTION
## Summary

- Adds Google-style docstrings (`Args` / `Returns` / `Raises`) to every function, method, and class in `src/atomistics` that was missing one
- Expands existing one-liner docstrings into full parameter descriptions where needed
- No logic changes — documentation only

## Files changed

| File | What was added |
|---|---|
| `calculators/interface.py` | `TaskEnum`, `TaskOutputEnum` class docstrings |
| `calculators/vasp.py` | `OutputParser` class + all 4 methods; `write_input`, `calc_static_with_vasp`, `optimize_positions_with_vasp`, `optimize_positions_and_volume_with_vasp`, `optimize_volume_with_vasp`, `optimize_cell_with_vasp`, `evaluate_with_vasp` |
| `calculators/sphinxdft.py` | `_generate_input`, `OutputParser` class + all 4 methods, `optimize_positions_with_sphinxdft`, `calc_static_with_sphinxdft`, `evaluate_with_sphinx` |
| `calculators/lammps/libcalculator.py` | All MD ensemble functions (NVT, NPT, NPH, Langevin, thermal expansion), `calc_static_with_lammpslib`, `optimize_positions*`, `evaluate_with_lammpslib*` |
| `calculators/lammps/filecalculator.py` | `GenericOutput` class + 4 methods, `_lammps_file_initialization`, `_write_lammps_input_file`, all 4 public functions |
| `calculators/lammps/helpers.py` | `lammps_run`, `lammps_calc_md_step`, `lammps_calc_md`, `lammps_thermal_expansion_loop`, `lammps_shutdown` |
| `calculators/lammps/shared.py` | `get_box_relax_command` |
| `calculators/lammps/melting.py` | Rewrote stubs in `_analyse_minimized_structure` and `_next_step_funct`; added full docstrings to `_generate_structure_with_fixed_number_of_atoms` and `estimate_melting_temperature_using_bisection_CNA` |
| `calculators/wrapper.py` | `evaluate_with_calculator` (nested function) |
| `shared/output.py` | All 10 `Output` dataclasses (`OutputStatic`, `OutputMolecularDynamics`, `OutputThermalExpansion`, `OutputThermodynamic`, `EquilibriumEnergy`, `EquilibriumVolume`, `EquilibriumBulkModul`, `EquilibriumBulkModulDerivative`, `OutputEnergyVolumeCurve`, `OutputElastic`, `OutputPhonons`) |
| `shared/import_warning.py` | `raise_warning` |
| `workflows/interface.py` | `Workflow` abstract base class |
| `workflows/elastic/helper.py` | `_get_eta_matrix` |

## Test plan

- [ ] Verify `python -c "import ast; ..."` passes (all files parse without syntax errors) ✅ confirmed before PR
- [ ] Confirm CI passes (no logic changes)
- [ ] Spot-check a few docstrings render correctly via `help()` or Sphinx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced code documentation across calculator and workflow modules with comprehensive docstrings and type annotations for calculator interfaces, LAMMPS, VASP, SPHINX implementations, and shared utilities. These improvements provide clearer documentation of parameters, return values, and function behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyiron/atomistics/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->