### PR TITLE
Extend unit test coverage for hessian, thermo, debye and elastic helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Git worktrees
+.worktrees/

--- a/src/atomistics/calculators/hessian.py
+++ b/src/atomistics/calculators/hessian.py
@@ -33,7 +33,7 @@ def check_force_constants(structure: Atoms, force_constants: np.ndarray) -> np.n
         na = np.newaxis
         return (
             np.array(force_constants)[:, na, :, na] * np.eye(3)[na, :, na, :]
-        ).flatten()
+        ).reshape(3 * n_atom, 3 * n_atom)
     elif len(np.shape(force_constants)) == 4:
         force_shape = np.shape(force_constants)
         if force_shape[2] == 3 and force_shape[3] == 3:

--- a/src/atomistics/workflows/evcurve/thermo.py
+++ b/src/atomistics/workflows/evcurve/thermo.py
@@ -210,7 +210,7 @@ class ThermoBulk:
                 raise ValueError()
         else:
             self._energies = (
-                np.ones((len(self.volumes), len(self.temperatures))) * erg_lst
+                np.ones((len(self.temperatures), len(self.volumes))) * erg_lst
             )
 
     def set_temperatures(
@@ -495,8 +495,8 @@ class ThermoBulk:
             import matplotlib.pyplot as plt
         if ax is None:
             fig, ax = plt.subplots(1, 1)
-            ax.xlabel(r"Volume [$\AA^3$]")
-            ax.ylabel("Temperature [K]")
+            ax.set_xlabel(r"Volume [$\AA^3$]")
+            ax.set_ylabel("Temperature [K]")
         ax.plot(self.get_minimum_energy_path(), self.temperatures, *args, **qwargs)
         return ax
 

--- a/tests/test_debye_model.py
+++ b/tests/test_debye_model.py
@@ -1,0 +1,146 @@
+import unittest
+
+import numpy as np
+
+from atomistics.workflows.evcurve.debye import (
+    DebyeModel,
+    DebyeThermalProperties,
+    debye_function,
+    get_thermal_properties_for_energy_volume_curve,
+)
+
+
+def _fit_dict():
+    return {
+        "energy_eq": -13.439961346483864,
+        "volume_eq": 66.43032532814925,
+        "bulkmodul_eq": 77.61265363975706,
+        "b_prime_eq": 1.2734991618131122,
+        "volume": [63.0, 64.0, 65.0, 66.0, 67.0, 68.0, 69.0],
+        "fit_dict": {
+            "fit_type": "vinet",
+        },
+    }
+
+
+class TestDebyeFunction(unittest.TestCase):
+    def test_debye_function_scalar(self):
+        result = debye_function(1.0)
+        self.assertIsInstance(result, float)
+        self.assertGreater(result, 0.0)
+
+    def test_debye_function_array(self):
+        result = debye_function(np.array([0.5, 1.0, 2.0]))
+        self.assertEqual(result.shape, (3,))
+
+
+class TestDebyeModel(unittest.TestCase):
+    def setUp(self):
+        self.masses = [26.98] * 4
+        self.model = DebyeModel(fit_dict=_fit_dict(), masses=self.masses, num_steps=10)
+
+    def test_volume_grid_spans_fit_dict_range(self):
+        self.assertEqual(self.model.volume.shape, (10,))
+        self.assertAlmostEqual(self.model.volume[0], 63.0)
+        self.assertAlmostEqual(self.model.volume[-1], 69.0)
+
+    def test_volume_setter_updates_min_and_max(self):
+        self.model.volume = np.linspace(60.0, 70.0, 5)
+        self.assertTrue(np.allclose(self.model.volume, [60.0, 62.5, 65.0, 67.5, 70.0]))
+
+    def test_debye_temperature_is_cached(self):
+        first = self.model.debye_temperature
+        second = self.model.debye_temperature
+        self.assertIs(first[0], second[0])
+        self.assertIs(first[1], second[1])
+
+    def test_debye_temperature_reset_after_volume_change(self):
+        first = self.model.debye_temperature
+        self.model.volume = np.linspace(60.0, 70.0, 5)
+        second = self.model.debye_temperature
+        self.assertIsNot(first[0], second[0])
+
+    def test_debye_temperature_multi_species_raises(self):
+        model = DebyeModel(fit_dict=_fit_dict(), masses=[26.98, 12.0], num_steps=10)
+        with self.assertRaises(NotImplementedError):
+            _ = model.debye_temperature
+
+    def test_energy_vib_with_explicit_scalar_debye_temperature(self):
+        energy = self.model.energy_vib(T=100.0, debye_T=300.0)
+        self.assertIsInstance(energy, float)
+
+    def test_energy_vib_low_vs_high_t_limit_differ(self):
+        low = self.model.energy_vib(T=np.array([300.0]), low_T_limit=True)
+        high = self.model.energy_vib(T=np.array([300.0]), low_T_limit=False)
+        self.assertFalse(np.allclose(low, high))
+
+
+class TestDebyeThermalProperties(unittest.TestCase):
+    def setUp(self):
+        self.masses = [26.98] * 4
+        self.fit_dict = _fit_dict()
+
+    def test_temperatures_generated_from_min_max_step(self):
+        props = DebyeThermalProperties(
+            fit_dict=self.fit_dict,
+            masses=self.masses,
+            t_min=0.0,
+            t_max=200.0,
+            t_step=50.0,
+            num_steps=10,
+        )
+        self.assertTrue(np.allclose(props.temperatures(), [0.0, 50.0, 100.0, 150.0, 200.0]))
+
+    def test_free_energy_shape_matches_temperatures(self):
+        props = DebyeThermalProperties(
+            fit_dict=self.fit_dict, masses=self.masses, num_steps=10
+        )
+        self.assertEqual(props.free_energy().shape, props.temperatures().shape)
+
+    def test_entropy_constant_pressure_vs_constant_volume_differ(self):
+        props_p = DebyeThermalProperties(
+            fit_dict=self.fit_dict, masses=self.masses, num_steps=10, constant_volume=False
+        )
+        props_v = DebyeThermalProperties(
+            fit_dict=self.fit_dict, masses=self.masses, num_steps=10, constant_volume=True
+        )
+        self.assertEqual(props_p.entropy().shape, props_v.entropy().shape)
+        self.assertFalse(np.allclose(props_p.entropy(), props_v.entropy()))
+
+    def test_heat_capacity_ends_with_nan_padding(self):
+        props = DebyeThermalProperties(
+            fit_dict=self.fit_dict, masses=self.masses, num_steps=10
+        )
+        heat_capacity = props.heat_capacity()
+        self.assertEqual(heat_capacity.shape, props.temperatures().shape)
+        self.assertTrue(np.all(np.isnan(heat_capacity[-2:])))
+
+    def test_volumes_constant_volume_is_equilibrium_volume(self):
+        props = DebyeThermalProperties(
+            fit_dict=self.fit_dict, masses=self.masses, num_steps=10, constant_volume=True
+        )
+        volumes = props.volumes()
+        self.assertTrue(np.allclose(volumes, self.fit_dict["volume"][0]))
+
+    def test_volumes_constant_pressure_follows_minimum_energy_path(self):
+        props = DebyeThermalProperties(
+            fit_dict=self.fit_dict, masses=self.masses, num_steps=10, constant_volume=False
+        )
+        volumes = props.volumes()
+        self.assertEqual(volumes.shape, props.temperatures().shape)
+
+
+class TestGetThermalPropertiesForEnergyVolumeCurve(unittest.TestCase):
+    def test_returns_requested_output_keys(self):
+        result = get_thermal_properties_for_energy_volume_curve(
+            fit_dict=_fit_dict(),
+            masses=[26.98] * 4,
+            num_steps=10,
+            output_keys=("temperatures", "free_energy", "volumes"),
+        )
+        self.assertEqual(set(result.keys()), {"temperatures", "free_energy", "volumes"})
+        self.assertEqual(result["temperatures"].shape, result["free_energy"].shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_elastic_workflow_helper.py
+++ b/tests/test_elastic_workflow_helper.py
@@ -1,0 +1,20 @@
+import unittest
+
+from ase.build import bulk
+
+from atomistics.workflows.elastic.helper import get_tasks_for_elastic_matrix
+
+
+class TestElasticWorkflowHelper(unittest.TestCase):
+    def setUp(self):
+        self.structure = bulk("Al", a=4.05, cubic=True)
+
+    def test_too_large_deformation_raises(self):
+        with self.assertRaises(Exception):
+            get_tasks_for_elastic_matrix(
+                structure=self.structure, eps_range=5.0, num_of_point=5
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -1,0 +1,197 @@
+import unittest
+
+import numpy as np
+from ase.build import bulk
+
+from atomistics.calculators.hessian import (
+    calc_forces_transformed,
+    check_force_constants,
+    evaluate_with_hessian,
+    get_displacement,
+    get_energy_pot,
+    get_forces,
+    get_pressure_times_volume,
+    get_stiffness_tensor,
+)
+
+
+class TestCheckForceConstants(unittest.TestCase):
+    def setUp(self):
+        self.structure = bulk("Al", cubic=True)
+        self.n_atom = len(self.structure)
+
+    def test_scalar_broadcasts_to_identity(self):
+        fc = check_force_constants(structure=self.structure, force_constants=2.0)
+        self.assertEqual(fc.shape, (3 * self.n_atom, 3 * self.n_atom))
+        self.assertTrue(np.allclose(fc, 2.0 * np.eye(3 * self.n_atom)))
+
+    def test_full_matrix_is_returned_unchanged(self):
+        full = np.arange((3 * self.n_atom) ** 2).reshape(
+            3 * self.n_atom, 3 * self.n_atom
+        )
+        fc = check_force_constants(structure=self.structure, force_constants=full)
+        self.assertTrue(np.array_equal(fc, full))
+
+    def test_atomwise_matrix_expands_to_block_diagonal(self):
+        atomwise = np.diag(np.arange(1, self.n_atom + 1).astype(float))
+        fc = check_force_constants(structure=self.structure, force_constants=atomwise)
+        self.assertEqual(fc.shape, (3 * self.n_atom, 3 * self.n_atom))
+        for i in range(self.n_atom):
+            block = fc[3 * i : 3 * i + 3, 3 * i : 3 * i + 3]
+            self.assertTrue(np.allclose(block, (i + 1) * np.eye(3)))
+        # off-diagonal atom pairs with zero coupling should vanish
+        self.assertTrue(np.allclose(fc[0:3, 3:6], np.zeros((3, 3))))
+
+    def test_4d_array_with_inner_3x3_axes(self):
+        n = self.n_atom
+        force_constants = np.zeros((n, n, 3, 3))
+        for i in range(n):
+            force_constants[i, i] = (i + 1) * np.eye(3)
+        fc = check_force_constants(structure=self.structure, force_constants=force_constants)
+        self.assertEqual(fc.shape, (3 * n, 3 * n))
+        for i in range(n):
+            block = fc[3 * i : 3 * i + 3, 3 * i : 3 * i + 3]
+            self.assertTrue(np.allclose(block, (i + 1) * np.eye(3)))
+
+    def test_4d_array_with_interleaved_3x3_axes(self):
+        n = self.n_atom
+        force_constants = np.zeros((n, 3, n, 3))
+        for i in range(n):
+            force_constants[i, :, i, :] = (i + 1) * np.eye(3)
+        fc = check_force_constants(structure=self.structure, force_constants=force_constants)
+        self.assertEqual(fc.shape, (3 * n, 3 * n))
+        for i in range(n):
+            block = fc[3 * i : 3 * i + 3, 3 * i : 3 * i + 3]
+            self.assertTrue(np.allclose(block, (i + 1) * np.eye(3)))
+
+    def test_unrecognized_2d_shape_raises(self):
+        with self.assertRaises(AssertionError):
+            check_force_constants(structure=self.structure, force_constants=np.zeros((2, 2)))
+
+    def test_unrecognized_4d_shape_raises(self):
+        with self.assertRaises(AssertionError):
+            check_force_constants(
+                structure=self.structure, force_constants=np.zeros((2, 2, 2, 2))
+            )
+
+    def test_missing_structure_raises(self):
+        with self.assertRaises(ValueError):
+            check_force_constants(structure=None, force_constants=1.0)
+
+
+class TestDisplacementAndForces(unittest.TestCase):
+    def setUp(self):
+        self.structure_equilibrium = bulk("Al", cubic=True)
+        self.structure = self.structure_equilibrium.copy()
+        self.structure.positions[0, 0] += 0.01
+        self.n_atom = len(self.structure)
+        self.force_constants = 5.0 * np.eye(3 * self.n_atom)
+
+    def test_get_displacement_zero_for_identical_structures(self):
+        displacements = get_displacement(self.structure_equilibrium, self.structure_equilibrium)
+        self.assertTrue(np.allclose(displacements, 0.0))
+
+    def test_get_displacement_matches_cartesian_shift(self):
+        displacements = get_displacement(self.structure_equilibrium, self.structure)
+        expected = np.zeros((self.n_atom, 3))
+        expected[0, 0] = 0.01
+        self.assertTrue(np.allclose(displacements, expected, atol=1e-8))
+
+    def test_calc_forces_transformed_matches_displacement(self):
+        forces_transformed, displacements = calc_forces_transformed(
+            force_constants=self.force_constants,
+            structure_equilibrium=self.structure_equilibrium,
+            structure=self.structure,
+        )
+        expected = -5.0 * displacements.flatten()
+        self.assertTrue(np.allclose(forces_transformed, expected, atol=1e-8))
+
+    def test_get_forces_is_hookes_law(self):
+        forces = get_forces(
+            force_constants=self.force_constants,
+            structure_equilibrium=self.structure_equilibrium,
+            structure=self.structure,
+        )
+        self.assertEqual(forces.shape, (self.n_atom, 3))
+        expected = np.zeros((self.n_atom, 3))
+        expected[0, 0] = -5.0 * 0.01
+        self.assertTrue(np.allclose(forces, expected, atol=1e-8))
+
+    def test_get_energy_pot_without_stress(self):
+        energy = get_energy_pot(
+            force_constants=self.force_constants,
+            structure_equilibrium=self.structure_equilibrium,
+            structure=self.structure,
+        )
+        expected = 0.5 * 5.0 * 0.01**2
+        self.assertAlmostEqual(energy, expected, places=8)
+
+    def test_get_energy_pot_at_equilibrium_is_zero(self):
+        energy = get_energy_pot(
+            force_constants=self.force_constants,
+            structure_equilibrium=self.structure_equilibrium,
+            structure=self.structure_equilibrium,
+        )
+        self.assertAlmostEqual(energy, 0.0, places=8)
+
+
+class TestStiffnessTensorAndPressure(unittest.TestCase):
+    def setUp(self):
+        self.structure_equilibrium = bulk("Al", cubic=True)
+
+    def test_get_stiffness_tensor_zero(self):
+        tensor = get_stiffness_tensor(bulk_modulus=0.0, shear_modulus=0.0)
+        self.assertTrue(np.allclose(tensor, np.zeros((6, 6))))
+
+    def test_get_stiffness_tensor_shape_and_symmetry(self):
+        tensor = get_stiffness_tensor(bulk_modulus=10.0, shear_modulus=2.0)
+        self.assertEqual(tensor.shape, (6, 6))
+        self.assertTrue(np.allclose(tensor[3:, 3:], 2.0 * np.eye(3)))
+        # off-diagonal coupling blocks are untouched (zero)
+        self.assertTrue(np.allclose(tensor[:3, 3:], np.zeros((3, 3))))
+
+    def test_pressure_times_volume_zero_stiffness_returns_zero(self):
+        stiffness_tensor = get_stiffness_tensor(bulk_modulus=0.0, shear_modulus=0.0)
+        result = get_pressure_times_volume(
+            stiffness_tensor=stiffness_tensor,
+            structure_equilibrium=self.structure_equilibrium,
+            structure=self.structure_equilibrium,
+        )
+        self.assertEqual(result, 0.0)
+
+    # Note: the nonzero-stiffness-tensor branch of get_pressure_times_volume has a
+    # pre-existing shape-mismatch bug (raises ValueError) that is out of scope to fix
+    # here; only the zero-stiffness branch (exercised above) is currently correct.
+
+
+class TestEvaluateWithHessian(unittest.TestCase):
+    def setUp(self):
+        self.structure_equilibrium = bulk("Al", cubic=True)
+        self.structure = self.structure_equilibrium.copy()
+        self.structure.positions[0, 0] += 0.01
+        self.force_constants = 5.0 * np.eye(3 * len(self.structure))
+
+    def test_calc_energy_and_forces(self):
+        result = evaluate_with_hessian(
+            task_dict={
+                "calc_energy": self.structure,
+                "calc_forces": self.structure,
+            },
+            structure_equilibrium=self.structure_equilibrium,
+            force_constants=self.force_constants,
+        )
+        self.assertIn("energy", result)
+        self.assertIn("forces", result)
+        self.assertAlmostEqual(result["energy"], 0.5 * 5.0 * 0.01**2, places=8)
+
+    def test_unsupported_task_raises(self):
+        with self.assertRaises(ValueError):
+            evaluate_with_hessian(
+                task_dict={"optimize_positions": self.structure},
+                structure_equilibrium=self.structure_equilibrium,
+                force_constants=self.force_constants,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_thermo_bulk.py
+++ b/tests/test_thermo_bulk.py
@@ -1,0 +1,235 @@
+import unittest
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from ase.build import bulk
+
+from atomistics.workflows.evcurve.debye import DebyeModel
+from atomistics.workflows.evcurve.thermo import ThermoBulk, get_thermo_bulk_model
+
+
+def _get_thermo_bulk_model():
+    volumes = [
+        63.10883669478296,
+        63.77314023893856,
+        64.43744378309412,
+        65.10174732724975,
+        65.7660508714054,
+        66.43035441556098,
+        67.09465795971657,
+        67.7589615038722,
+        68.42326504802779,
+        69.08756859218344,
+        69.75187213633905,
+    ]
+    return get_thermo_bulk_model(
+        temperatures=np.arange(1.0, 1550.0, 50.0),
+        debye_model=DebyeModel(
+            fit_dict={
+                "energy_eq": -13.439961346483864,
+                "volume_eq": 66.43032532814925,
+                "bulkmodul_eq": 77.61265363975706,
+                "b_prime_eq": 1.2734991618131122,
+                "volume": volumes,
+                "fit_dict": {
+                    "fit_type": "vinet",
+                },
+            },
+            masses=bulk("Al", cubic=True).get_masses(),
+            num_steps=50,
+        ),
+    )
+
+
+class TestThermoBulkValidation(unittest.TestCase):
+    def setUp(self):
+        self.thermo = ThermoBulk()
+
+    def test_temperatures_unset_raises(self):
+        with self.assertRaises(ValueError):
+            _ = self.thermo.temperatures
+
+    def test_temperatures_setter_requires_list_like(self):
+        with self.assertRaises(ValueError):
+            self.thermo.temperatures = 300.0
+
+    def test_volumes_unset_raises(self):
+        with self.assertRaises(ValueError):
+            _ = self.thermo.volumes
+
+    def test_volumes_setter_requires_list_like(self):
+        with self.assertRaises(ValueError):
+            self.thermo.volumes = 10.0
+
+    def test_energies_unset_raises(self):
+        with self.assertRaises(ValueError):
+            _ = self.thermo.energies
+
+
+class TestThermoBulkEnergiesSetter(unittest.TestCase):
+    def setUp(self):
+        self.thermo = ThermoBulk()
+        self.thermo.temperatures = np.linspace(0, 100, 5)
+        self.thermo.volumes = np.linspace(10, 20, 3)
+
+    def test_energies_2d_passthrough(self):
+        energies = np.arange(15).reshape(5, 3).astype(float)
+        self.thermo.energies = energies
+        self.assertTrue(np.array_equal(self.thermo.energies, energies))
+
+    def test_energies_1d_matching_volumes_is_tiled_per_temperature(self):
+        per_volume = np.array([1.0, 2.0, 3.0])
+        self.thermo.energies = per_volume
+        self.assertEqual(self.thermo.energies.shape, (5, 3))
+        for row in self.thermo.energies:
+            self.assertTrue(np.array_equal(row, per_volume))
+
+    def test_energies_1d_mismatched_length_raises(self):
+        with self.assertRaises(ValueError):
+            self.thermo.energies = np.array([1.0, 2.0])
+
+    def test_energies_scalar_broadcasts_with_temperature_volume_convention(self):
+        self.thermo.energies = -2.0
+        self.assertEqual(self.thermo.energies.shape, (5, 3))
+        self.assertTrue(np.allclose(self.thermo.energies, -2.0))
+
+
+class TestThermoBulkSetters(unittest.TestCase):
+    def setUp(self):
+        self.thermo = ThermoBulk()
+
+    def test_set_temperatures_defaults(self):
+        self.thermo.set_temperatures()
+        self.assertEqual(len(self.thermo.temperatures), 50)
+        self.assertEqual(self.thermo.temperatures[0], 0.0)
+        self.assertEqual(self.thermo.temperatures[-1], 1500.0)
+
+    def test_set_volumes_default_max_is_1_1_times_min(self):
+        self.thermo.set_volumes(volume_min=10.0, volume_steps=5)
+        self.assertEqual(len(self.thermo.volumes), 5)
+        self.assertAlmostEqual(self.thermo.volumes[0], 10.0)
+        self.assertAlmostEqual(self.thermo.volumes[-1], 11.0)
+
+    def test_set_volumes_explicit_max(self):
+        self.thermo.set_volumes(volume_min=10.0, volume_max=20.0, volume_steps=3)
+        self.assertTrue(np.allclose(self.thermo.volumes, [10.0, 15.0, 20.0]))
+
+    def test_meshgrid_shapes(self):
+        self.thermo.set_temperatures(temperature_steps=4)
+        self.thermo.set_volumes(volume_min=10.0, volume_max=20.0, volume_steps=3)
+        x_grid, y_grid = self.thermo.meshgrid()
+        self.assertEqual(x_grid.shape, (4, 3))
+        self.assertEqual(y_grid.shape, (4, 3))
+
+
+class TestThermoBulkMinimumEnergyPath(unittest.TestCase):
+    def test_linear_energies_have_no_minimum(self):
+        thermo = ThermoBulk()
+        thermo._fit_order = 1
+        thermo.temperatures = np.linspace(0, 100, 5)
+        thermo.volumes = np.linspace(10, 20, 3)
+        thermo.energies = np.array([1.0, 0.5, 0.0])
+        path = thermo.get_minimum_energy_path()
+        self.assertTrue(np.all(np.isnan(path)))
+
+    def test_pressure_not_implemented(self):
+        thermo = ThermoBulk()
+        thermo.temperatures = np.linspace(0, 100, 5)
+        thermo.volumes = np.linspace(10, 20, 3)
+        thermo.energies = np.array([1.0, 0.5, 0.0])
+        with self.assertRaises(NotImplementedError):
+            thermo.get_minimum_energy_path(pressure=1.0)
+
+
+class TestThermoBulkFreeEnergyAndInterpolation(unittest.TestCase):
+    def setUp(self):
+        self.thermo = _get_thermo_bulk_model()
+
+    def test_get_free_energy_matches_polyval(self):
+        vol = self.thermo.volumes[0]
+        free_energy = self.thermo.get_free_energy(vol)
+        expected = np.polyval(self.thermo._coeff, vol)
+        self.assertTrue(np.allclose(free_energy, expected))
+
+    def test_get_free_energy_with_pressure_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.thermo.get_free_energy(self.thermo.volumes[0], pressure=1.0)
+
+    def test_interpolate_volume_returns_new_object_with_consistent_shape(self):
+        new_volumes = self.thermo.volumes[:5]
+        interpolated = self.thermo.interpolate_volume(new_volumes)
+        self.assertIsNot(interpolated, self.thermo)
+        self.assertEqual(len(interpolated.volumes), 5)
+        self.assertEqual(
+            interpolated.energies.shape, (len(self.thermo.temperatures), 5)
+        )
+
+    def test_interpolate_volume_with_explicit_fit_order(self):
+        interpolated = self.thermo.interpolate_volume(
+            self.thermo.volumes[:3], fit_order=2
+        )
+        self.assertEqual(self.thermo._fit_order, 2)
+        self.assertEqual(len(interpolated.volumes), 3)
+
+    def test_get_free_energy_p_shape(self):
+        free_energy_p = self.thermo.get_free_energy_p()
+        self.assertEqual(free_energy_p.shape, self.thermo.temperatures.shape)
+
+    def test_get_entropy_p_shape(self):
+        entropy_p = self.thermo.get_entropy_p()
+        self.assertEqual(entropy_p.shape, self.thermo.temperatures.shape)
+
+    def test_get_entropy_v_shape(self):
+        entropy_v = self.thermo.get_entropy_v()
+        self.assertEqual(entropy_v.shape, self.thermo.temperatures.shape)
+
+
+class TestThermoBulkPlotting(unittest.TestCase):
+    def setUp(self):
+        self.thermo = _get_thermo_bulk_model()
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_plot_free_energy(self):
+        self.thermo.plot_free_energy()
+
+    def test_plot_entropy(self):
+        self.thermo.plot_entropy()
+
+    def test_plot_heat_capacity_in_kB(self):
+        self.thermo.plot_heat_capacity(to_kB=True)
+
+    def test_plot_heat_capacity_in_joules(self):
+        self.thermo.plot_heat_capacity(to_kB=False)
+
+    def test_contour_pressure(self):
+        self.thermo.contour_pressure()
+
+    def test_contour_entropy(self):
+        self.thermo.contour_entropy()
+
+    def test_plot_contourf_creates_axes_when_none_given(self):
+        ax = self.thermo.plot_contourf()
+        self.assertIsNotNone(ax)
+
+    def test_plot_contourf_with_existing_axes_and_min_erg_path(self):
+        fig, ax = plt.subplots(1, 1)
+        result = self.thermo.plot_contourf(ax=ax, show_min_erg_path=True)
+        self.assertIs(result, ax)
+
+    def test_plot_min_energy_path_creates_axes_when_none_given(self):
+        ax = self.thermo.plot_min_energy_path()
+        self.assertIsNotNone(ax)
+
+    def test_plot_min_energy_path_with_existing_axes(self):
+        fig, ax = plt.subplots(1, 1)
+        result = self.thermo.plot_min_energy_path(ax=ax)
+        self.assertIs(result, ax)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds dependency-free unit tests for `atomistics.calculators.hessian`, `atomistics.workflows.evcurve.thermo` (`ThermoBulk`), `atomistics.workflows.evcurve.debye` (`DebyeModel`/`DebyeThermalProperties`), and the elastic workflow helper's deformation guard.
- Raises coverage on these modules from roughly 51–80% to 90–99%, and overall repo coverage from 80% to 89% in a non-MPI/no-external-codes test run.
- Fixes three latent bugs uncovered while writing tests, none of which were reachable by any existing test:
  - `check_force_constants` (hessian.py) returned a flattened 1D array instead of a `(3n, 3n)` matrix for the per-atom force-constants input shape, which would crash any downstream `np.dot` call.
  - `ThermoBulk.energies`'s scalar-broadcast setter branch built the energy array with shape `(n_volumes, n_temperatures)` instead of the `(n_temperatures, n_volumes)` convention used everywhere else in the class.
  - `ThermoBulk.plot_min_energy_path` called the nonexistent `Axes.xlabel()`/`ylabel()` methods instead of `set_xlabel()`/`set_ylabel()`.
- `get_pressure_times_volume`'s nonzero-stiffness-tensor branch has a similar pre-existing bug (shape-mismatch crash, and a silently dropped diagonal-stress term) that needs elasticity-theory domain review to fix correctly — left untouched/uncovered here and flagged separately.

## Test plan
- [x] `pytest tests/test_hessian.py tests/test_thermo_bulk.py tests/test_debye_model.py tests/test_elastic_workflow_helper.py -v` — all new tests pass.
- [x] Full `pytest tests/` run before and after: same 17 pre-existing, environment-dependent failures (missing `CONDA_PREFIX`/SPHInX potentials, network-fetched MACE/GRACE models) in both runs — no regressions introduced.
- [x] `pre-commit run` (ruff lint + format) passes on all changed/new files.